### PR TITLE
Serialize IndexedDB chapter-answer read-modify-write cycles

### DIFF
--- a/app/js/gestures.js
+++ b/app/js/gestures.js
@@ -135,24 +135,16 @@ document.addEventListener('visibilitychange', () => {
   if (!ch || !studyId) return;
 
   (async () => {
-    let record;
     try {
-      record = await StudyIDB.getChapterAnswers(studyId, ch.chapterNumber);
-    } catch (e) {
-      console.warn('[visibilitychange] IDB read failed; falling back to empty object.', e);
-      record = {};
-    }
-
-    document.querySelectorAll('.answer-field').forEach(field => {
-      const type  = field.dataset.type;
-      const index = field.dataset.index;
-      if (type !== undefined && index !== undefined) {
-        record[answerFieldKey(type, index)] = field.value;
-      }
-    });
-
-    try {
-      await StudyIDB.setChapterAnswers(studyId, ch.chapterNumber, record);
+      await StudyIDB.updateChapterAnswers(studyId, ch.chapterNumber, record => {
+        document.querySelectorAll('.answer-field').forEach(field => {
+          const type  = field.dataset.type;
+          const index = field.dataset.index;
+          if (type !== undefined && index !== undefined) {
+            record[answerFieldKey(type, index)] = field.value;
+          }
+        });
+      }, 'visibilitychange');
     } catch (e) {
       console.warn('[visibilitychange] IDB write failed.', e);
     }

--- a/app/js/idb.js
+++ b/app/js/idb.js
@@ -253,6 +253,52 @@ const StudyIDB = (() => {
     });
   }
 
+  // ── Serialized chapter-answer updates ──────────────────────────────────────
+  // getChapterAnswers()/setChapterAnswers() each open their own IndexedDB
+  // transaction, so a bare read-modify-write is never atomic — two callers
+  // updating the same chapter's record close together race, and whichever
+  // set() lands second silently overwrites the other's change. This queues
+  // updates per chapter key so concurrent callers run their read-mutate-write
+  // cycle one at a time instead of racing. All call sites that used to
+  // read-modify-write via getChapterAnswers()/setChapterAnswers() directly
+  // (saveAnswers(), blur auto-save, saveLikertAnswer(), toggleStar(), the
+  // visibilitychange flush, and the voice-transcript recovery path) go
+  // through this instead.
+  const _chapterUpdateQueues = new Map();
+
+  // mutate(record) is called synchronously with the current record (or a
+  // fresh {} if none exists yet, or the read failed) and should modify it in
+  // place. Resolves with the updated record on success; rejects if the write
+  // fails. A failed read falls back to {} (logged via `tag`) rather than
+  // aborting, matching the pre-existing fallback used at every call site.
+  async function updateChapterAnswers(studyId, chapterNum, mutate, tag = 'updateChapterAnswers') {
+    const key  = chapterAnswersIDBKey(studyId, chapterNum);
+    const prev = _chapterUpdateQueues.get(key) || Promise.resolve();
+    const run = prev.catch(() => {}).then(async () => {
+      let record;
+      try {
+        record = await getChapterAnswers(studyId, chapterNum);
+      } catch (e) {
+        console.warn(`[${tag}] IDB read failed; falling back to empty object.`, e);
+        record = {};
+      }
+      mutate(record);
+      await setChapterAnswers(studyId, chapterNum, record);
+      return record;
+    });
+    _chapterUpdateQueues.set(key, run);
+    // Drop the queue entry once settled so it doesn't grow unboundedly over a
+    // long session. Handled via .then(onFulfilled, onRejected) rather than
+    // .finally() so this cleanup can't itself produce an unhandled-rejection
+    // warning — the `run` promise returned below still carries the real
+    // result/error for the caller.
+    run.then(
+      () => { if (_chapterUpdateQueues.get(key) === run) _chapterUpdateQueues.delete(key); },
+      () => { if (_chapterUpdateQueues.get(key) === run) _chapterUpdateQueues.delete(key); }
+    );
+    return run;
+  }
+
   // Deletes all answer records for a study: chapter objects, global_notes,
   // and lastPosition. Used by confirmClearAnswers() and deleteStudy().
   // Returns the list of deleted keys (useful for logging/debugging).
@@ -346,7 +392,7 @@ const StudyIDB = (() => {
     // images store
     getImage, setImage, removeImage, removeImagesByPrefix,
     // answers store
-    getChapterAnswers, setChapterAnswers,
+    getChapterAnswers, setChapterAnswers, updateChapterAnswers,
     getAnswerRaw, setAnswerRaw, deleteAnswerRaw,
     deleteStudyAnswers, getAllStudyAnswerKeys, getAllAnswerEntries,
     // global

--- a/app/js/save.js
+++ b/app/js/save.js
@@ -24,38 +24,24 @@ async function saveAnswers(isManual = true) {
   const ch      = chapters[currentChapter];
   if (!studyId || !ch) return;
 
-  // Read the existing chapter object first so we preserve any fields not
-  // currently visible (e.g. from a different element type or a prior save).
-  let record;
-  try {
-    record = await StudyIDB.getChapterAnswers(studyId, ch.chapterNumber);
-  } catch (e) {
-    console.warn('[saveAnswers] IDB read failed; falling back to empty object.', e);
-    record = {};
-  }
+  // Collect the visible answer fields that actually contain something.
+  // Blank fields are skipped rather than stomping the record with an empty
+  // string — same rationale as the blur auto-save below: clearing a field's
+  // stored answer should be a deliberate action, not a side effect of an
+  // empty field being present on screen when Save is tapped.
+  const fields = Array.from(document.querySelectorAll('.answer-field')).filter(
+    field => field.dataset.type !== undefined && field.dataset.index !== undefined && field.value.trim() !== ''
+  );
 
-  // Overwrite only the fields that are visible in the DOM right now and
-  // actually contain something. Blank fields are skipped rather than
-  // stomping the record with an empty string — same rationale as the
-  // blur auto-save below: clearing a field's stored answer should be a
-  // deliberate action, not a side effect of an empty field being present
-  // on screen when Save is tapped.
-  const fields = document.querySelectorAll('.answer-field');
-  let anyNonBlank = false;
-  fields.forEach(field => {
-    const type  = field.dataset.type;
-    const index = field.dataset.index;
-    if (type !== undefined && index !== undefined && field.value.trim() !== '') {
-      record[answerFieldKey(type, index)] = field.value;
-      anyNonBlank = true;
-    }
-  });
-
-  // Nothing to save — skip the write and the toast entirely.
-  if (!anyNonBlank) return;
+  // Nothing to save — skip the read/write and the toast entirely.
+  if (fields.length === 0) return;
 
   try {
-    await StudyIDB.setChapterAnswers(studyId, ch.chapterNumber, record);
+    await StudyIDB.updateChapterAnswers(studyId, ch.chapterNumber, record => {
+      fields.forEach(field => {
+        record[answerFieldKey(field.dataset.type, field.dataset.index)] = field.value;
+      });
+    }, 'saveAnswers');
   } catch (e) {
     console.warn('[saveAnswers] IDB write failed.', e);
   }
@@ -119,18 +105,10 @@ document.addEventListener('blur', e => {
 
   // Fire-and-forget async save for the single field that lost focus.
   (async () => {
-    let record;
     try {
-      record = await StudyIDB.getChapterAnswers(studyId, ch.chapterNumber);
-    } catch (e) {
-      console.warn('[blur auto-save] IDB read failed; falling back to empty object.', e);
-      record = {};
-    }
-
-    record[answerFieldKey(type, index)] = value;
-
-    try {
-      await StudyIDB.setChapterAnswers(studyId, ch.chapterNumber, record);
+      await StudyIDB.updateChapterAnswers(studyId, ch.chapterNumber, record => {
+        record[answerFieldKey(type, index)] = value;
+      }, 'blur auto-save');
     } catch (e) {
       console.warn('[blur auto-save] IDB write failed.', e);
     }
@@ -163,18 +141,10 @@ async function saveLikertAnswer(elementId, stIdx, value, chapterNumber) {
   const studyId = window.activeStudyId;
   if (chapterNumber == null || !studyId) return;
 
-  let record;
   try {
-    record = await StudyIDB.getChapterAnswers(studyId, chapterNumber);
-  } catch (e) {
-    console.warn('[saveLikertAnswer] IDB read failed; falling back to empty object.', e);
-    record = {};
-  }
-
-  record[likertFieldKey(elementId, stIdx)] = value;
-
-  try {
-    await StudyIDB.setChapterAnswers(studyId, chapterNumber, record);
+    await StudyIDB.updateChapterAnswers(studyId, chapterNumber, record => {
+      record[likertFieldKey(elementId, stIdx)] = value;
+    }, 'saveLikertAnswer');
   } catch (e) {
     console.warn('[saveLikertAnswer] IDB write failed.', e);
   }

--- a/app/js/starred.js
+++ b/app/js/starred.js
@@ -48,25 +48,18 @@ async function toggleStar(chapterNum, elementId) {
   const studyId = window.activeStudyId;
   if (!studyId) return;
 
-  let record;
-  try {
-    record = await StudyIDB.getChapterAnswers(studyId, chapterNum);
-  } catch (e) {
-    console.warn('[toggleStar] IDB read failed.', e);
-    return;
-  }
-
-  const field     = starFieldKey(elementId);
-  const currently = record[field] === '1';
-
-  if (currently) {
-    delete record[field];
-  } else {
-    record[field] = '1';
-  }
+  const field = starFieldKey(elementId);
+  let currently;
 
   try {
-    await StudyIDB.setChapterAnswers(studyId, chapterNum, record);
+    await StudyIDB.updateChapterAnswers(studyId, chapterNum, record => {
+      currently = record[field] === '1';
+      if (currently) {
+        delete record[field];
+      } else {
+        record[field] = '1';
+      }
+    }, 'toggleStar');
   } catch (e) {
     console.warn('[toggleStar] IDB write failed.', e);
     return;

--- a/app/js/voice.js
+++ b/app/js/voice.js
@@ -171,20 +171,13 @@ function receiveVoiceTranscript(transcript) {
     const studyId = window.activeStudyId;
     if (studyId) {
       (async () => {
-        let record;
-        try {
-          record = await StudyIDB.getChapterAnswers(studyId, pending.chapterNumber);
-        } catch (e) {
-          console.warn('[voice recovery] IDB read failed; falling back to empty object.', e);
-          record = {};
-        }
-
         const fieldKey = answerFieldKey(pending.type, pending.index);
-        const current  = record[fieldKey] || '';
-        record[fieldKey] = current ? current.trimEnd() + ' ' + transcript : transcript;
 
         try {
-          await StudyIDB.setChapterAnswers(studyId, pending.chapterNumber, record);
+          await StudyIDB.updateChapterAnswers(studyId, pending.chapterNumber, record => {
+            const current = record[fieldKey] || '';
+            record[fieldKey] = current ? current.trimEnd() + ' ' + transcript : transcript;
+          }, 'voice recovery');
         } catch (e) {
           console.warn('[voice recovery] IDB write failed.', e);
           return;


### PR DESCRIPTION
## Summary
- `getChapterAnswers()`/`setChapterAnswers()` each open their own IndexedDB transaction, so every call site that did a bare read-modify-write on a chapter's answer record could race against any other and silently drop a write (e.g. saving an answer in one field while starring a different question in the same chapter).
- Adds `StudyIDB.updateChapterAnswers(studyId, chapterNum, mutate, tag)` — queues updates per chapter key so concurrent callers run their read-mutate-write cycle one at a time instead of racing. Different chapters/studies still run independently (no unnecessary serialization).
- Migrates all 6 call sites that had this pattern: `saveAnswers()`, the blur auto-save listener, `saveLikertAnswer()` (save.js), `toggleStar()` (starred.js), the `visibilitychange` flush (gestures.js), and the voice-transcript recovery path (voice.js).
- `migrate.js`'s one-time startup migration still uses `getChapterAnswers`/`setChapterAnswers` directly — intentionally out of scope (it runs once before these other paths are live).
- Minor behavior note: `toggleStar()` previously aborted entirely on a read failure; it now falls back to an empty record and proceeds, matching the fallback already used by the other 5 sites.

## Verification
No automated test suite exists in this repo. Verified the queueing algorithm in isolation against a fake IDB backend with artificial async delay (see conversation) — confirmed: (1) the old unsafe pattern does race under concurrent updates (only 1/3 fields survived in the test), (2) the new serialized version preserves all concurrent updates, (3) unrelated chapters/studies still run in parallel rather than being needlessly serialized, (4) a failed write doesn't wedge the queue for subsequent updates. All 5 changed files pass `node --check`.

## Test plan
- [ ] On a real device/browser: open a chapter, type an answer in one question, then immediately (within ~1s) tap the star on a different question and toggle a Likert response in the same chapter. Reload and confirm all three persisted.
- [ ] Confirm normal single-field save/auto-save/star/likert still work as before.
- [ ] Confirm backgrounding the app (visibilitychange) and voice input still save correctly.