### PR TITLE
Consolidate IndexedDB answers-store key builders

### DIFF
--- a/app/js/idb.js
+++ b/app/js/idb.js
@@ -195,15 +195,15 @@ const StudyIDB = (() => {
 
   // ── answers store (per-chapter answer objects) ────────────────────────────
   //
-  // Chapter answers key:  `${studyId}_ch${chapterNum}`
-  // Global notes key:     `${studyId}_global_notes`
-  // Last position key:    `${studyId}_lastPosition`
+  // Chapter answers key:  chapterAnswersIDBKey(studyId, chapterNum) — state.js
+  // Global notes key:     globalNotesIDBKey(studyId) — state.js
+  // Last position key:    lastPositionIDBKey(studyId) — state.js
 
   // Returns the answer object for a single chapter, or {} if none exists yet.
   async function getChapterAnswers(studyId, chapterNum) {
     const db = await open();
     return new Promise((resolve, reject) => {
-      const key = `${studyId}_ch${chapterNum}`;
+      const key = chapterAnswersIDBKey(studyId, chapterNum);
       const req = db.transaction(ANS_STORE, 'readonly').objectStore(ANS_STORE).get(key);
       req.onsuccess = e => resolve(e.target.result ?? {});
       req.onerror   = e => reject(e.target.error);
@@ -214,7 +214,7 @@ const StudyIDB = (() => {
   async function setChapterAnswers(studyId, chapterNum, obj) {
     const db = await open();
     return new Promise((resolve, reject) => {
-      const key = `${studyId}_ch${chapterNum}`;
+      const key = chapterAnswersIDBKey(studyId, chapterNum);
       const req = db.transaction(ANS_STORE, 'readwrite').objectStore(ANS_STORE).put(obj, key);
       req.onsuccess = () => resolve();
       req.onerror   = e => reject(e.target.error);

--- a/app/js/migrate.js
+++ b/app/js/migrate.js
@@ -162,7 +162,7 @@ async function _migrateStudy(studyId) {
     if (lsKey === `${prefix}global_notes`) {
       const val = localStorage.getItem(lsKey);
       if (val !== null) {
-        rawIDBWrites.push({ key: `${studyId}_global_notes`, value: val });
+        rawIDBWrites.push({ key: globalNotesIDBKey(studyId), value: val });
         keysToRemove.push(lsKey);
       }
       continue;
@@ -175,7 +175,7 @@ async function _migrateStudy(studyId) {
     if (lsKey === lastPositionLSKey) {
       const val = localStorage.getItem(lsKey);
       if (val !== null) {
-        rawIDBWrites.push({ key: `${studyId}_lastPosition`, value: val });
+        rawIDBWrites.push({ key: lastPositionIDBKey(studyId), value: val });
         keysToRemove.push(lsKey);
       }
       continue;

--- a/app/js/render-progress.js
+++ b/app/js/render-progress.js
@@ -628,7 +628,7 @@ async function renderNotesPage() {
   // Load saved global notes from IDB.
   let savedText = '';
   try {
-    const raw = await StudyIDB.getAnswerRaw(`${currentStudyId}_global_notes`);
+    const raw = await StudyIDB.getAnswerRaw(globalNotesIDBKey(currentStudyId));
     savedText = escapeHtml(raw || '');
   } catch (e) {
     console.warn('[renderNotesPage] IDB read failed for global_notes.', e);
@@ -694,7 +694,7 @@ let _saveGlobalNotesTimer = null;
 function _saveGlobalNotes(value, studyId) {
   clearTimeout(_saveGlobalNotesTimer);
   _saveGlobalNotesTimer = setTimeout(() => {
-    StudyIDB.setAnswerRaw(`${studyId}_global_notes`, value)
+    StudyIDB.setAnswerRaw(globalNotesIDBKey(studyId), value)
       .catch(e => console.warn('[_saveGlobalNotes] IDB write failed.', e));
   }, 400);
 }
@@ -790,7 +790,7 @@ async function renderMenu() {
     // Check IDB for global notes presence.
     let hasNotesContent = false;
     try {
-      const raw = await StudyIDB.getAnswerRaw(`${currentStudyId}_global_notes`);
+      const raw = await StudyIDB.getAnswerRaw(globalNotesIDBKey(currentStudyId));
       hasNotesContent = !!(raw && raw.trim());
     } catch (e) { /* no notes saved yet */ }
     html += `

--- a/app/js/share-print.js
+++ b/app/js/share-print.js
@@ -103,7 +103,7 @@ async function exportStudyAnswers() {
   // Also load global notes.
   let globalNotes = '';
   try {
-    globalNotes = (await StudyIDB.getAnswerRaw(`${studyId}_global_notes`)) || '';
+    globalNotes = (await StudyIDB.getAnswerRaw(globalNotesIDBKey(studyId))) || '';
   } catch (e) { /* no global notes */ }
 
   let report = bold(`${meta.title || t('shareprint_default_study_title')}`) + '\n';
@@ -429,7 +429,7 @@ async function printAllChapters() {
   // Pre-load all chapter records and global notes in parallel.
   const [records, globalNotes] = await Promise.all([
     _loadAllChapterRecords(studyId),
-    StudyIDB.getAnswerRaw(`${studyId}_global_notes`).catch(() => ''),
+    StudyIDB.getAnswerRaw(globalNotesIDBKey(studyId)).catch(() => ''),
   ]);
 
   const cover = `<div class="cover">

--- a/app/js/state.js
+++ b/app/js/state.js
@@ -105,3 +105,13 @@ function chapterAnswersIDBKey(studyId, chapterNum) {
   return `${studyId}_ch${chapterNum}`;
 }
 
+// Returns the IDB answers-store key for a study's global (non-chapter-scoped) notes.
+function globalNotesIDBKey(studyId) {
+  return `${studyId}_global_notes`;
+}
+
+// Returns the IDB answers-store key for a study's last reading position.
+function lastPositionIDBKey(studyId) {
+  return `${studyId}_lastPosition`;
+}
+

--- a/app/js/study-loader.js
+++ b/app/js/study-loader.js
@@ -719,7 +719,7 @@ async function applyStudyData(data, { isStudySwitch = false, silent = false } = 
   window.lastPositionCache = null;
   if (appSettings.rememberPosition && window.activeStudyId) {
     try {
-      const raw = await StudyIDB.getAnswerRaw(`${window.activeStudyId}_lastPosition`);
+      const raw = await StudyIDB.getAnswerRaw(lastPositionIDBKey(window.activeStudyId));
       window.lastPositionCache = raw ? JSON.parse(raw) : null;
     } catch (e) {
       window.lastPositionCache = null;

--- a/app/js/utils.js
+++ b/app/js/utils.js
@@ -50,7 +50,7 @@ function saveLastPosition() {
   // Keep the sync cache up to date so renderTitlePage() sees the latest position.
   window.lastPositionCache = pos;
   // Fire-and-forget — position loss on failure is acceptable.
-  StudyIDB.setAnswerRaw(`${studyId}_lastPosition`, JSON.stringify(pos))
+  StudyIDB.setAnswerRaw(lastPositionIDBKey(studyId), JSON.stringify(pos))
     .catch(e => console.warn('[saveLastPosition] IDB write failed.', e));
 }
 
@@ -62,7 +62,7 @@ function clearLastPosition() {
   const studyId = window.activeStudyId;
   if (!studyId) return;
   window.lastPositionCache = null;
-  StudyIDB.deleteAnswerRaw(`${studyId}_lastPosition`)
+  StudyIDB.deleteAnswerRaw(lastPositionIDBKey(studyId))
     .catch(e => console.warn('[clearLastPosition] IDB delete failed.', e));
 }
 
@@ -73,7 +73,7 @@ async function getLastPosition() {
   const studyId = window.activeStudyId;
   if (!studyId) return null;
   try {
-    const raw = await StudyIDB.getAnswerRaw(`${studyId}_lastPosition`);
+    const raw = await StudyIDB.getAnswerRaw(lastPositionIDBKey(studyId));
     return raw ? JSON.parse(raw) : null;
   } catch (e) {
     return null;


### PR DESCRIPTION
## Summary
- The chapter-answers, global-notes, and last-position IDB key formats were each hand-typed inline at 12 call sites across 6 files — including twice inside `idb.js`'s own `getChapterAnswers()`/`setChapterAnswers()`, which didn't use the `chapterAnswersIDBKey()` helper that already exists in `state.js` for exactly that key.
- Adds `globalNotesIDBKey(studyId)` and `lastPositionIDBKey(studyId)` next to the existing `chapterAnswersIDBKey()`/`celebratedIDBKey()`/`starFieldKey()` helpers in `state.js`, and sweeps every call site (idb.js, migrate.js, render-progress.js, share-print.js, study-loader.js, utils.js) to use them.
- Pure refactor — verified each helper produces the byte-identical string the inline template did, so this changes no observable behavior. All touched files pass `node --check`.

## Test plan
- [ ] Global notes: type in Notes page, navigate away and back, confirm it persists.
- [ ] Last position: read partway through a chapter, background/reopen the app, confirm it resumes at the same scroll position.
- [ ] Fresh install (or clear site data): confirm the one-time migration in migrate.js still runs cleanly for a pre-migration user.