### PR TITLE
Fix Android cold-start gaps: appReady guard, double onboarding

### DIFF
--- a/app/js/app-init.js
+++ b/app/js/app-init.js
@@ -370,13 +370,26 @@ async function startApp() {
   window._appReady = true;
 
   // Case 0: Android delivered a .estudy file before DOMContentLoaded fired.
-  // pendingStudyData is already persisted to IDB by loadStudyFromJson,
-  // so we just need to apply it. Show app onboarding first if it hasn't been
-  // seen (so the user gets the intro before landing in the study).
+  // pendingStudyData is already persisted to IDB by loadStudyFromJson (or
+  // deferred the same way by loadStudyFromFile's _activateOrDeferStudy), so
+  // we just need to apply it. applyStudyData() calls initApp() internally
+  // (silent is not passed), which already shows app onboarding first and
+  // only falls back to study onboarding if it didn't fire — so there's no
+  // need to call showAppOnboardingIfNeeded() here too.
+  //
+  // This used to also call showAppOnboardingIfNeeded() directly *and* fire
+  // applyStudyData() without awaiting it. Since app_onboarding_complete is
+  // only set once the user finishes or skips the slides (not the moment
+  // they're shown), the unawaited applyStudyData() chain would reach
+  // initApp()'s own showAppOnboardingIfNeeded() call within milliseconds —
+  // almost always before the user finished slide 1 — and that second call
+  // would see the flag still unset and re-fire showAppOnboarding(), which
+  // tears down and rebuilds the same overlay from slide 1, resetting the
+  // user's progress through it.
   if (window.pendingStudyData) {
-    showAppOnboardingIfNeeded();
-    applyStudyData(window.pendingStudyData);
+    const data = window.pendingStudyData;
     window.pendingStudyData = null;
+    await applyStudyData(data);
     return;
   }
 

--- a/app/js/study-loader.js
+++ b/app/js/study-loader.js
@@ -729,6 +729,30 @@ async function applyStudyData(data, { isStudySwitch = false, silent = false } = 
   if (!silent) await initApp({ isStudySwitch });
 } // end applyStudyData
 
+// Activates a study that has just been installed/verified-current if the app
+// has finished starting up, or defers it via window.pendingStudyData for
+// startApp() to pick up otherwise — the same pattern loadStudyFromJson() uses
+// (see below). Needed because loadStudyFromFile() — and transitively
+// loadStudyFromBase64()/loadAnyFile(), the Android bridge's file-open entry
+// point — can be invoked before DOMContentLoaded has fired. Without this
+// guard, applying the study immediately would render before locale/settings
+// have loaded (showing raw i18n keys), and startApp() would later re-apply
+// the same pendingStudyData-less study a second time via its own routing,
+// causing a redundant re-render. checkEstudyVersion() only runs on the
+// immediate-activation path — like loadStudyFromJson(), it's skipped on the
+// deferred path since it depends on window.appAboutData, which isn't loaded
+// yet either.
+async function _activateOrDeferStudy(studyId, data, { checkVersion = false } = {}) {
+  if (studyId) window.activeStudyId = studyId;
+  if (window._appReady) {
+    if (checkVersion) checkEstudyVersion(data);
+    await Router.navigate({ page: 'library' });
+    await applyStudyData(data, { isStudySwitch: true });
+  } else {
+    window.pendingStudyData = data;
+  }
+}
+
 // wrapper to parse string handed over from Android
 // Called by the Android WebView bridge when the user opens a .estudy file.
 // This may be called BEFORE or AFTER DOMContentLoaded fires, so we handle both:
@@ -1226,9 +1250,7 @@ async function loadStudyFromFile(file) {
         // instead of silently doing nothing.
         const existing = await StudyIDB.get(`study_content_${studyId}`);
         if (existing) {
-          await Router.navigate({ page: 'library' });
-          window.activeStudyId = studyId;
-          await applyStudyData(existing, { isStudySwitch: true });
+          await _activateOrDeferStudy(studyId, existing);
           return;
         }
       }
@@ -1307,10 +1329,7 @@ async function loadStudyFromFile(file) {
       // this study's own image URLs and then have applyStudyData's revoke step
       // immediately invalidate them — producing "blob:... net::ERR_FILE_NOT_FOUND"
       // on every single file load, deterministically.
-      checkEstudyVersion(data);
-      await Router.navigate({ page: 'library' });
-      window.activeStudyId = studyId;
-      await applyStudyData(data, { isStudySwitch: true });
+      await _activateOrDeferStudy(studyId, data, { checkVersion: true });
 
     } else {
       // ── Legacy plain-JSON .estudy ─────────────────────────────────────────
@@ -1334,9 +1353,7 @@ async function loadStudyFromFile(file) {
           // incoming file instead of silently doing nothing.
           const existing = await StudyIDB.get(`study_content_${_plainStudyId}`);
           if (existing) {
-            await Router.navigate({ page: 'library' });
-            window.activeStudyId = _plainStudyId;
-            await applyStudyData(existing, { isStudySwitch: true });
+            await _activateOrDeferStudy(_plainStudyId, existing);
             return;
           }
         }
@@ -1354,9 +1371,7 @@ async function loadStudyFromFile(file) {
         if (_incomingVer > 0) _setInstalledStudyVersion(_plainStudyId, _incomingVer);
       }
 
-      checkEstudyVersion(data);
-      await Router.navigate({ page: 'library' });
-      await applyStudyData(data, { isStudySwitch: true });
+      await _activateOrDeferStudy(_plainStudyId, data, { checkVersion: true });
     }
 
   } catch (err) {


### PR DESCRIPTION
## Summary
- `loadStudyFromFile()` — reached via `loadAnyFile()` from `loadStudyFromBase64()`, the Android bridge's file-open entry point — applied studies immediately at all 4 of its activation points, with no check for `window._appReady`. `loadStudyFromJson()` (the other Android bridge entry point) already guards this exact timing case: the bridge can call these functions before `DOMContentLoaded` fires. Added `_activateOrDeferStudy()`, mirroring `loadStudyFromJson()`'s existing `if (window._appReady) {...} else { window.pendingStudyData = data; ... }` pattern, and used it at all 4 sites (zip-format skip/install, legacy plain-JSON skip/install). Without this, a study delivered before app-ready would render with untranslated UI (locale not loaded yet) and then get re-applied a second time once `startApp()` ran its own routing.
- `startApp()`'s Case 0 (`pendingStudyData`) branch called `showAppOnboardingIfNeeded()` directly *and* fired `applyStudyData()` without awaiting it. Since `applyStudyData()` → `initApp()` already calls `showAppOnboardingIfNeeded()` itself, and `app_onboarding_complete` is only set once the user finishes/skips the slides (not the moment they're shown), the unawaited chain reached `initApp()`'s own call within milliseconds — before the user could finish slide 1 in practice — and `showSlideOverlay()` tears down + rebuilds the same overlay id, resetting the user back to slide 1 mid-interaction. Now just awaits `applyStudyData()` and lets `initApp()` be the sole onboarding decision point.

**Known follow-up, not fixed here:** `loadBundleFromFile()` also calls `Router.navigate()`/`showToast()` unconditionally with no appReady guard. It doesn't call `applyStudyData()`, so the double-render/untranslated-UI failure mode described above doesn't apply, but it has its own narrower risk if a bundle `.zip` is opened via the Android bridge before `DOMContentLoaded`. Flagging separately rather than expanding this PR's scope.

## Verification
No automated test suite exists in this repo. Verified both fixes' control flow in isolation with small Node simulations (see conversation): (1) the old Case-0 structure fires the onboarding overlay twice, the new structure fires it once; (2) `_activateOrDeferStudy()` correctly activates immediately when `_appReady` is true (navigate + apply, with `checkEstudyVersion` only when requested) and correctly defers via `pendingStudyData` without touching the DOM/router when `_appReady` is false. Both files pass `node --check`.

## Test plan
- [ ] Normal manual file-picker load (zip and legacy plain-JSON) still works and activates the study immediately, in both the fresh-install and same-version-reinstall cases.
- [ ] On Android: open a `.estudy` file via intent ("Open with") on a cold app start — confirm no flash of untranslated UI and no duplicate re-render.
- [ ] On a genuinely fresh install, confirm the app onboarding slides play through normally without resetting mid-way.