### PR TITLE
Fix four independent correctness bugs

### DIFF
--- a/app/js/app-init.js
+++ b/app/js/app-init.js
@@ -409,7 +409,7 @@ async function startApp() {
       const data = await StudyIDB.get(`study_content_${lastStudyId}`);
       if (data) {
         window.activeStudyId = lastStudyId;
-        applyStudyData(data);
+        await applyStudyData(data);
         // applyStudyData → initApp() handles position restore internally.
         return;
       }

--- a/app/js/locales/en/ui_en.json
+++ b/app/js/locales/en/ui_en.json
@@ -548,6 +548,7 @@
   "settings_clear_answers_confirm"                      :"Clear answers",
   "settings_clear_answers_cancel"                       :"Cancel",
   "settings_clear_answers_toast"                        :"✓ All answers cleared",
+  "settings_clear_answers_error"                        :"Couldn't clear answers — please try again",
   "___subsection: resetToDefaults"                      :"── resetToDefaults() ────────────────────────────────────",
   "settings_reset_title"                                :"Reset to defaults?",
   "settings_reset_body"                                 :"This will reset all your settings (font size, dark mode, and other preferences) back to their original defaults. The onboarding introduction will also play again on next launch.<br><br>Your answers, notes, progress, and current reading position will <strong>not</strong> be affected.",

--- a/app/js/modals.js
+++ b/app/js/modals.js
@@ -221,11 +221,15 @@ function renderLikertScale(el, chNum, chapterAnswers = null) {
     ).join('');
   }
 
-  // Safely escape title and instruction for single-quoted onclick args.
-  // Scale is stored as a data attribute (JSON) to avoid double-quote
-  // collision with the surrounding HTML attribute delimiters.
-  const safeTitle = (el.popupTitle || '').replace(/'/g, "\\'");
-  const safeInstr = (el.instruction || '').replace(/'/g, "\\'");
+  // Safely escape title and instruction for use as single-quoted JS string
+  // literals inside the onclick attribute below. Two escapes are needed
+  // since they're nested inside each other: '/g -> \' keeps an embedded
+  // single quote from closing the JS string literal early, and "/g ->
+  // &quot; keeps an embedded double quote from closing the surrounding
+  // onclick="..." HTML attribute early (the same collision scaleJson
+  // below avoids for its own data attribute).
+  const safeTitle = (el.popupTitle || '').replace(/'/g, "\\'").replace(/"/g, '&quot;');
+  const safeInstr = (el.instruction || '').replace(/'/g, "\\'").replace(/"/g, '&quot;');
   const scaleJson = JSON.stringify(scale).replace(/"/g, '&quot;');
 
   return `

--- a/app/js/settings.js
+++ b/app/js/settings.js
@@ -206,6 +206,9 @@ function confirmClearAnswers() {
       await StudyIDB.deleteStudyAnswers(currentStudyId);
     } catch (e) {
       console.warn('[confirmClearAnswers] IDB delete failed.', e);
+      // Don't report success or navigate away — the answers are still there.
+      showToast({ message: t('settings_clear_answers_error'), isManual: true });
+      return;
     }
 
     clearLastPosition();

--- a/app/js/share-print.js
+++ b/app/js/share-print.js
@@ -36,25 +36,35 @@ async function shareAnswers() {
   report += bold(t('shareprint_answers_header', { title: ch.chapterTitle, number: ch.chapterNumber })) + '\n';
   report += `------------------------------------------\n\n`;
 
-  const qFields = document.querySelectorAll('.answer-field[data-type="q"]');
-  let qIndex = 0;
+  // Look up each field by its elementId (data-index) rather than by position
+  // in the NodeList — a question whose repeatElement reference doesn't
+  // resolve is skipped by the chapter renderer (render-chapter.js's element
+  // loop), which would silently shift every subsequent positional index and
+  // misattribute answers to the wrong question. ch.sections is built
+  // independently and always lists every question regardless of whether its
+  // field actually rendered.
   ch.sections.forEach(section => {
     section.questions.forEach(q => {
-      const field  = qFields[qIndex];
+      const field  = document.querySelector(`.answer-field[data-type="q"][data-index="${CSS.escape(q.elementId)}"]`);
       const answer = (field && field.value.trim()) ? field.value.trim() : t('shareprint_no_answer');
       report += `${bold(t('shareprint_label_ref'))} ${q.ref}\n`;
       report += `${bold(t('shareprint_label_q'))} ${q.text}\n`;
       report += `${bold(t('shareprint_label_a'))} ${answer}\n\n`;
-      qIndex++;
     });
   });
 
   if (ch.reflection && ch.reflection.length > 0) {
     report += bold(t('shareprint_reflection_heading')) + '\n';
     report += `------------------------------------------\n`;
-    const rFields = document.querySelectorAll('.answer-field[data-type="r"]');
+    // ch.reflection is an array of question-text strings built positionally
+    // from the same filtered element list starred.js's getStarredQuestions()
+    // uses — reconstruct that list here to resolve each entry's elementId.
+    const reflEls = (ch.elements || []).filter(
+      e => e.type === 'question' && e.subtype === 'reflection' && !e.repeatElement
+    );
     ch.reflection.forEach((qText, rIdx) => {
-      const field  = rFields[rIdx];
+      const eid    = reflEls[rIdx] ? reflEls[rIdx].elementId : null;
+      const field  = eid ? document.querySelector(`.answer-field[data-type="r"][data-index="${CSS.escape(eid)}"]`) : null;
       const answer = (field && field.value.trim()) ? field.value.trim() : t('shareprint_no_answer');
       report += `${bold(t('shareprint_label_q'))} ${qText}\n`;
       report += `${bold(t('shareprint_label_a'))} ${answer}\n\n`;


### PR DESCRIPTION
## Summary
Four independent, unrelated fixes bundled together since each is small and low-risk on its own:

- **app-init.js** — `applyStudyData(data)` was called without `await` in `startApp()`'s Case 1 (restore last active study) branch, inside a try/catch specifically meant to handle its failures. An async exception (e.g. a corrupted/malformed stored study) became an unhandled rejection instead of triggering the "failed to restore" toast + library fallback. Added the missing `await`.
- **modals.js** — `renderLikertScale()`'s `safeTitle`/`safeInstr` only escaped single quotes before being interpolated into a double-quoted `onclick` attribute. A study's `popupTitle`/`instruction` containing a literal `"` broke the attribute (confirmed — see conversation for a concrete before/after test). Now also escapes `"` → `&quot;`, mirroring `scaleJson` two lines below, which already handles the identical collision for its own data attribute.
- **share-print.js** — `shareAnswers()` matched each question/reflection to its answer by positional index into the DOM's `.answer-field` NodeList. A question whose `repeatElement` reference doesn't resolve is skipped entirely by the chapter renderer, silently shifting every subsequent index and misattributing answers to the wrong question in the shared/printed report. Now looks up each field directly by its `elementId` (the `data-index` attribute the renderer already sets), matching the pattern `exportStudyAnswers()` and `starred.js` already use elsewhere in this codebase.
- **settings.js** — `confirmClearAnswers()` showed the "✓ All answers cleared" success toast and navigated to the title page even when `StudyIDB.deleteStudyAnswers()` failed. Now shows a new `settings_clear_answers_error` toast and stops instead, since the answers are in fact still there. New key added to `ui_en.json` only — other locales fall back to English automatically for missing keys per the existing i18n convention.

## Verification
No automated test suite exists in this repo. Verified the modals.js fix with a concrete Node test building the actual attribute string with a title containing a double quote — confirmed 2 stray unescaped quotes before the fix (attribute genuinely breaks), 0 after. All 4 touched JS files pass `node --check`; `ui_en.json` still parses as valid JSON.

## Test plan
- [ ] Cold-start the app with a study set as last-active — confirm it restores normally (this path is the common case and shouldn't change).
- [ ] Add a Likert element to a test study with a `"` in its `popupTitle` or `instruction`, confirm the info popup opens correctly and the card isn't visually broken.
- [ ] In a chapter, leave one question blank and answer others, tap Share — confirm each answer lines up with the correct question. If possible, test with a study that has a question with an unresolved `repeatElement` to directly exercise the fixed case.
- [ ] Settings → Clear Answers under normal conditions still clears and shows the success toast.