### PR TITLE
Parallelize sequential IndexedDB fetches; dedupe pathway double-fetch

### DIFF
--- a/app/js/app-init.js
+++ b/app/js/app-init.js
@@ -223,17 +223,18 @@ function rerenderCurrentView() {
 // no corresponding data (e.g. from a partially-failed delete or stale state).
 async function cleanOrphanedRegistry() {
   const registry = JSON.parse(localStorage.getItem('study_registry') || '[]');
-  const valid = [];
-  for (const id of registry) {
-    let exists;
-    try {
-      exists = await StudyIDB.get(`study_content_${id}`);
-    } catch (err) {
-      if (err.name === 'IDBUnavailable') { _showIdbUnavailableError(); return; }
-      throw err;
-    }
-    if (exists) valid.push(id);
+  let results;
+  try {
+    // Runs on every startup before any routing decision — fetch every
+    // registry entry in parallel rather than one IDB round-trip at a time,
+    // so N installed studies costs roughly one round-trip's worth of
+    // latency instead of N, directly off the critical path to first paint.
+    results = await Promise.all(registry.map(id => StudyIDB.get(`study_content_${id}`)));
+  } catch (err) {
+    if (err.name === 'IDBUnavailable') { _showIdbUnavailableError(); return; }
+    throw err;
   }
+  const valid = registry.filter((id, i) => !!results[i]);
   if (valid.length !== registry.length) {
     console.warn('cleanOrphanedRegistry: removed', registry.length - valid.length, 'orphaned ID(s)');
     const removed = registry.length - valid.length;

--- a/app/js/render-chapter.js
+++ b/app/js/render-chapter.js
@@ -162,6 +162,26 @@ async function renderChapter(idx, scrollY = 0) {
       }
     });
 
+    // ── Pre-fetch not-yet-cached inline images in parallel ────────────────────
+    // Collects every image element's cache key up front and fetches all of
+    // them at once, so the elements loop below can read exclusively from
+    // _imageBlobCache and stay fully synchronous. Previously each uncached
+    // image's blob was awaited one at a time inside the loop, adding a full
+    // sequential IDB round-trip per image to first-visit chapter navigation.
+    const _uncachedImageKeys = [];
+    (ch.elements || []).forEach(el => {
+      const resolved = el.repeatElement ? elementMap[el.repeatElement] : el;
+      if (!resolved || resolved.type !== 'image') return;
+      const cacheKey = `${window.activeStudyId}_${resolved.elementId}`;
+      if (!_imageBlobCache.has(cacheKey)) _uncachedImageKeys.push(cacheKey);
+    });
+    if (_uncachedImageKeys.length > 0) {
+      await Promise.all(_uncachedImageKeys.map(async cacheKey => {
+        const blob = await StudyIDB.getImage(cacheKey);
+        if (blob) _imageBlobCache.set(cacheKey, _createBlobUrl(blob));
+      }));
+    }
+
     // ── Pre-load chapter answer object from IDB ───────────────────────────────
     // Fetched once here so every renderer in the elements loop below can read
     // saved answer values and star flags synchronously from this plain object,
@@ -249,23 +269,14 @@ async function renderChapter(idx, scrollY = 0) {
           break;
 
         case 'image': {
-          // Resolve the image src before calling the synchronous renderer.
-          // Priority: IDB blob (zip-imported studies) → el.src → empty string.
+          // Resolve the image src. Priority: IDB blob (zip-imported studies,
+          // pre-fetched into _imageBlobCache above) → el.src → empty string.
           // Blob URLs are memoised in _imageBlobCache (keyed by elementId) so
           // IDB is only read once per image per study session. URLs are
           // registered via _createBlobUrl() and revoked (along with the cache)
           // by _revokeAllBlobUrls() when a new study is loaded.
-          let imgSrc = resolved.src || '';
           const cacheKey = `${window.activeStudyId}_${resolved.elementId}`;
-          if (_imageBlobCache.has(cacheKey)) {
-            imgSrc = _imageBlobCache.get(cacheKey);
-          } else {
-            const blob = await StudyIDB.getImage(cacheKey);
-            if (blob) {
-              imgSrc = _createBlobUrl(blob);
-              _imageBlobCache.set(cacheKey, imgSrc);
-            }
-          }
+          const imgSrc = _imageBlobCache.has(cacheKey) ? _imageBlobCache.get(cacheKey) : (resolved.src || '');
           contentHtml += renderImage({ ...ctx, imgSrc });
           break;
         }

--- a/app/js/render-library.js
+++ b/app/js/render-library.js
@@ -364,10 +364,19 @@ async function renderLibrary() {
   // For multilingual studies, title/subtitle are resolved to the active language
   // (window._activeStudyLang), falling back to slot 1 if the active language is
   // not one of this study's languages. Mono-lingual studies use plain fields.
+  // Fetch every registered study's metadata in parallel rather than one IDB
+  // round-trip at a time — with N installed studies this cuts N sequential
+  // full-content-blob reads down to roughly one round-trip's worth of
+  // latency. Only meta/title/subtitle/etc. are kept afterward; the full
+  // parsed `data` object is used transiently below (fallback icon lookup)
+  // and is not read anywhere else in this file, so it's not retained in
+  // studyCache — holding on to every installed study's full content
+  // (chapters, questions, likert scales, ...) for the library screen's
+  // lifetime would be a needless memory footprint.
   const studyCache = {};
-  for (const id of registry) {
+  const studyEntries = await Promise.all(registry.map(async (id) => {
     const data = await StudyIDB.get(`study_content_${id}`);
-    if (!data) continue;
+    if (!data) return null;
     let coverSrc = '';
     if (_coverCache.has(id)) {
       coverSrc = _coverCache.get(id);
@@ -421,8 +430,7 @@ async function renderLibrary() {
       _langs.push(meta.language);
     }
 
-    studyCache[id] = {
-      data,
+    return [id, {
       meta,
       title:    _res('title', 'Untitled Study').trim(),
       subtitle: _res('subtitle', ''),
@@ -431,8 +439,9 @@ async function renderLibrary() {
       langs:    _langs,          // ordered array of all language codes for this study
       lang:     _langs[0] || '', // primary language (for legacy single-lang filter)
       coverSrc,
-    };
-  }
+    }];
+  }));
+  studyEntries.forEach(entry => { if (entry) studyCache[entry[0]] = entry[1]; });
 
   // ── Helper: small cover image HTML ──────────────────────────────────────────
   function smallCoverHtml(entry, wClass, fbClass) {

--- a/app/js/render-progress.js
+++ b/app/js/render-progress.js
@@ -51,18 +51,32 @@ function clearActivePathway() {
   renderProgressOverview();
 }
 
-// Counts answered questions for an arbitrary studyId by reading answer keys
-// from IDB. Does not require the study to be loaded.
-// Returns a Promise resolving to { answered, total }.
-async function getStudyProgressForId(studyId) {
-  let answered = 0;
-  let total    = 0;
+// Fetches every chapter's answer record for studyId once, in parallel, and
+// returns per-chapter counts: [{ chNum, total, answered }, ...] sorted by
+// chapter number. This is the single source both getStudyProgressForId()
+// (aggregate) and _buildPathwayStudyDetailHtml() (per-chapter breakdown)
+// build on, so a pathway study's chapters are only read from IDB once —
+// they used to be read once per function, once each, sequentially.
+// A single chapter's read failure doesn't abort the others; it just
+// contributes { total: 0, answered: 0 } for that chapter and logs a warning.
+async function _getStudyChapterCounts(studyId) {
+  let keys = [];
   try {
-    const keys = await StudyIDB.getAllStudyAnswerKeys(studyId);
-    // Keys are like `${studyId}_ch${N}` — load each chapter object and count
-    const chapterKeys = keys.filter(k => /^.+_ch\d+$/.test(k));
-    for (const key of chapterKeys) {
-      const chNum = parseInt(key.match(/_ch(\d+)$/)[1], 10);
+    keys = await StudyIDB.getAllStudyAnswerKeys(studyId);
+  } catch (e) {
+    console.warn('[_getStudyChapterCounts] IDB read failed.', e);
+    return [];
+  }
+
+  // Keys are like `${studyId}_ch${N}` — extract the chapter numbers.
+  const chNums = [...new Set(
+    keys.map(k => { const m = k.match(/_ch(\d+)$/); return m ? Number(m[1]) : null; })
+        .filter(n => n !== null)
+  )].sort((a, b) => a - b);
+
+  return Promise.all(chNums.map(async chNum => {
+    let total = 0, answered = 0;
+    try {
       const record = await StudyIDB.getChapterAnswers(studyId, chNum);
       for (const [field, val] of Object.entries(record)) {
         // Count question (q_), reflection (r_), and Likert (likert_) fields only
@@ -70,11 +84,22 @@ async function getStudyProgressForId(studyId) {
         total++;
         if ((val || '').trim()) answered++;
       }
+    } catch (e) {
+      console.warn(`[_getStudyChapterCounts] IDB read failed for ch${chNum}.`, e);
     }
-  } catch (e) {
-    console.warn('[getStudyProgressForId] IDB read failed.', e);
-  }
-  return { answered, total };
+    return { chNum, total, answered };
+  }));
+}
+
+// Counts answered questions for an arbitrary studyId by reading answer keys
+// from IDB. Does not require the study to be loaded.
+// Returns a Promise resolving to { answered, total }.
+async function getStudyProgressForId(studyId) {
+  const chapterCounts = await _getStudyChapterCounts(studyId);
+  return chapterCounts.reduce(
+    (acc, c) => ({ answered: acc.answered + c.answered, total: acc.total + c.total }),
+    { answered: 0, total: 0 }
+  );
 }
 
 // Returns the position (1-based) of studyId within the given pathway's
@@ -355,7 +380,11 @@ async function _buildPathwayPanelHtml(pathway) {
   const studyRowsArr = await Promise.all((pathway.studyTitles || []).map(async (s, idx) => {
     const isActive   = s.studyId === window.activeStudyId;
     const inRegistry = registry.includes(s.studyId);
-    const { answered, total } = await getStudyProgressForId(s.studyId);
+    const chapterCounts = await _getStudyChapterCounts(s.studyId);
+    const { answered, total } = chapterCounts.reduce(
+      (acc, c) => ({ answered: acc.answered + c.answered, total: acc.total + c.total }),
+      { answered: 0, total: 0 }
+    );
     pathwayAnswered += answered;
     pathwayTotal    += total;
 
@@ -390,7 +419,7 @@ async function _buildPathwayPanelHtml(pathway) {
             ? t('progress_detail_open_to_start')
             : t('progress_detail_not_installed')}
          </div>`
-      : await _buildPathwayStudyDetail(s.studyId, answered, total);
+      : _buildPathwayStudyDetailHtml(chapterCounts);
 
     return `
       <div class="prog-pathway-study-item ${isActive ? 'is-active-study' : ''}">
@@ -447,39 +476,14 @@ async function _buildPathwayPanelHtml(pathway) {
 }
 
 // Builds the per-chapter detail rows shown when a pathway study is expanded.
-// Reads chapter answer records from IDB for the given studyId.
-async function _buildPathwayStudyDetail(studyId, answered, total) {
-  let keys = [];
-  try {
-    keys = await StudyIDB.getAllStudyAnswerKeys(studyId);
-  } catch (e) {
-    console.warn('[_buildPathwayStudyDetail] IDB read failed.', e);
-  }
-
-  // Extract chapter numbers from keys like `${studyId}_ch${N}`
-  const chNums = new Set();
-  keys.forEach(k => {
-    const match = k.match(/_ch(\d+)$/);
-    if (match) chNums.add(Number(match[1]));
-  });
-
-  if (chNums.size === 0) {
+// Takes the chapter counts _buildPathwayPanelHtml() already fetched via
+// _getStudyChapterCounts() — no IDB reads of its own, and no longer async.
+function _buildPathwayStudyDetailHtml(chapterCounts) {
+  if (chapterCounts.length === 0) {
     return `<div class="prog-pathway-detail-empty">${t('progress_detail_no_answers')}</div>`;
   }
 
-  const rowsArr = await Promise.all([...chNums].sort((a, b) => a - b).map(async chNum => {
-    let chTotal    = 0;
-    let chAnswered = 0;
-    try {
-      const record = await StudyIDB.getChapterAnswers(studyId, chNum);
-      for (const [field, val] of Object.entries(record)) {
-        if (!/^(q_|r_|likert_)/.test(field)) continue;
-        chTotal++;
-        if ((val || '').trim()) chAnswered++;
-      }
-    } catch (e) {
-      console.warn(`[_buildPathwayStudyDetail] IDB read failed for ch${chNum}.`, e);
-    }
+  const rows = chapterCounts.map(({ chNum, total: chTotal, answered: chAnswered }) => {
     const pct       = chTotal > 0 ? Math.round((chAnswered / chTotal) * 100) : 0;
     const ringColor = pct === 100 ? 'var(--success)' : pct > 0 ? 'var(--accent)' : 'var(--border)';
     const isDone    = pct === 100;
@@ -494,9 +498,9 @@ async function _buildPathwayStudyDetail(studyId, answered, total) {
           ${isDone ? '✓' : chAnswered === 0 ? '—' : `${chAnswered}/${chTotal}`}
         </div>
       </div>`;
-  }));
+  }).join('');
 
-  return `<div class="prog-pathway-detail-list">${rowsArr.join('')}</div>`;
+  return `<div class="prog-pathway-detail-list">${rows}</div>`;
 }
 
 // Toggles the expand/collapse of a single study's detail block in the pathway tab.

--- a/app/js/search.js
+++ b/app/js/search.js
@@ -198,13 +198,26 @@ function getSuggestion(query) {
 // in save.js — no change needed there.
 const storageCache = new Map();
 
+// Which study storageCache currently holds data for — used to force a reload
+// on study switch even though switching studies doesn't itself clear the
+// cache (only the save paths above do, via storageCache.clear()).
+let _storageCacheStudyId = null;
+
 // Loads all chapter answer objects for the active study into storageCache.
 // Keyed by chapter number (integer). Returns a Promise that resolves when all
-// reads are complete. Called once at the start of each runSearchCore() execution.
+// reads are complete. Called at the start of each runSearchCore() execution,
+// but skips the reload entirely when the cache is already populated for the
+// active study — every save path clears storageCache when an answer changes,
+// so a non-empty, same-study cache is already current. Without this, every
+// debounced keystroke-pause while the user is still typing the same search
+// re-read every chapter's IDB record for no reason.
 async function _loadAnswerCache() {
-  storageCache.clear();
   const studyId = window.activeStudyId;
-  if (!studyId) return;
+  if (!studyId) { storageCache.clear(); _storageCacheStudyId = null; return; }
+  if (storageCache.size > 0 && _storageCacheStudyId === studyId) return;
+
+  storageCache.clear();
+  _storageCacheStudyId = studyId;
   await Promise.all(
     chapters.map(async ch => {
       try {


### PR DESCRIPTION
## Summary
Five independent efficiency fixes, all the same shape: replace N sequential IDB round-trips with one parallel batch, or skip a redundant re-fetch outright. First sub-PR of the broader efficiency/cleanup pass (PR 6) — split out to keep the diff reviewable; more will follow.

- **render-library.js** — `renderLibrary()` fetched every registered study's full content blob one at a time just to read title/subtitle/cover. Now parallel via `Promise.all`. The full parsed blob is no longer retained in `studyCache` (grepped — nothing else in the file reads it), avoiding the memory cost of holding every installed study's full content for the library screen's lifetime.
- **render-progress.js** — `getStudyProgressForId()` and `_buildPathwayStudyDetail()` independently re-fetched and re-read every chapter's answer record for the same study, back to back. Added `_getStudyChapterCounts(studyId)` as the single fetch both now build on — `getStudyProgressForId()` sums it for the aggregate count, `_buildPathwayStudyDetailHtml()` (no longer async, no IDB reads of its own) renders per-chapter rows directly from it. Also parallelizes the per-chapter reads themselves, previously sequential.
- **app-init.js** — `cleanOrphanedRegistry()` validated the study registry against IDB one entry at a time on every startup, before any routing decision — directly on the critical path to first paint. Now `Promise.all`.
- **render-chapter.js** — uncached inline images were fetched one at a time inside the chapter-elements render loop. Added a parallel pre-fetch pass before the loop so the image case can read `_imageBlobCache` synchronously.
- **search.js** — `_loadAnswerCache()` unconditionally re-read every chapter's answer record on every debounced keystroke-pause, even when nothing had changed since the previous search. Now skips the reload when the cache is already populated for the active study. Tracks which study the cache belongs to (`_storageCacheStudyId`) so switching studies still forces a reload even though study-switch doesn't itself clear `storageCache` (only the save paths do) — without that check this optimization would leak stale cross-study answers into search results after a study switch with no intervening save.

## Verification
No automated test suite exists in this repo. Verified with isolated Node simulations against mocked `StudyIDB` (see conversation):
- render-progress.js: confirmed `_getStudyChapterCounts` produces correct per-chapter and aggregate counts, and that `getAllStudyAnswerKeys`/`getChapterAnswers` are each called exactly once per chapter across the whole per-study flow (previously twice).
- search.js: confirmed the cache-skip sequence across 4 scenarios — first search fetches, a same-study re-search with no save in between skips the fetch, a save-then-search reloads, and switching studies with no save in between still forces a reload (the specific regression this fix has to avoid).

All 5 touched files pass `node --check`.

## Test plan
- [ ] Library screen with several installed studies still shows correct titles/covers/subtitles/language badges.
- [ ] Progress → Pathway tab: aggregate percentage and per-study expanded chapter breakdown still show correct, matching numbers.
- [ ] App cold-start with several installed studies — no change in behavior, just faster.
- [ ] Open a chapter with multiple images for the first time — all images still load correctly.
- [ ] Search: type a query, get results; edit an answer, search again — updated answer appears in results. Switch to a different study and search — results reflect the new study, not the previous one.