### PR TITLE
Reuse existing helpers instead of hand-rolled reimplementations

### DIFF
--- a/app/js/modals.js
+++ b/app/js/modals.js
@@ -496,8 +496,11 @@ function openInfoModal(infoId, content, triggerBtn) {
   document.getElementById('infoModalShowAgain').checked = true;
 
   // Store context so closeInfoModal() can act on the right button and key.
-  _currentInfoTriggerBtn          = triggerBtn;
-  _currentInfoTriggerBtn._infoId  = infoId;
+  // triggerBtn is null when opened directly rather than from a ⓘ icon (e.g.
+  // openNotesInfo()) — closeInfoModal() already only reads _infoId when
+  // _currentInfoTriggerBtn is truthy, so there's nothing to store in that case.
+  _currentInfoTriggerBtn = triggerBtn;
+  if (_currentInfoTriggerBtn) _currentInfoTriggerBtn._infoId = infoId;
 
   document.getElementById('info-modal-overlay').classList.add('open');
 }

--- a/app/js/render-library.js
+++ b/app/js/render-library.js
@@ -1336,12 +1336,7 @@ async function renderLibrary() {
    */
   window.libPathDownload = function(url) {
   if (!url || url === '' || url.includes('placeholder.com')) {
-    const toast = document.getElementById('toast');
-    if (toast) {
-      toast.textContent = t('renderlib_download_coming_soon');
-      toast.classList.add('show');
-      setTimeout(() => toast.classList.remove('show'), 2500);
-    }
+    showToast({ message: t('renderlib_download_coming_soon'), isManual: true, duration: 2500 });
     return;
   }
 

--- a/app/js/render-progress.js
+++ b/app/js/render-progress.js
@@ -687,30 +687,30 @@ async function renderNotesPage() {
   }
 }
 
-// Debounce timer for _saveGlobalNotes — prevents an IDB write on every
-// keystroke. Mirrors the pattern used for updateProgress in save.js.
-let _saveGlobalNotesTimer = null;
-
-// Saves the global notes value to IDB after a short debounce. Fire-and-forget
-// — called from the oninput handler on the globalNotesField textarea.
+// Saves the global notes value to IDB after a short debounce — prevents an
+// IDB write on every keystroke. Fire-and-forget — called from the oninput
+// handler on the globalNotesField textarea. Uses the shared debounce()
+// helper from search.js instead of a hand-rolled timer.
 // The debounce does not affect updateNotesMenuIndicator(), which is called
 // directly in the oninput attribute and updates instantly on every keystroke.
-function _saveGlobalNotes(value, studyId) {
-  clearTimeout(_saveGlobalNotesTimer);
-  _saveGlobalNotesTimer = setTimeout(() => {
-    StudyIDB.setAnswerRaw(globalNotesIDBKey(studyId), value)
-      .catch(e => console.warn('[_saveGlobalNotes] IDB write failed.', e));
-  }, 400);
-}
+const _saveGlobalNotes = debounce((value, studyId) => {
+  StudyIDB.setAnswerRaw(globalNotesIDBKey(studyId), value)
+    .catch(e => console.warn('[_saveGlobalNotes] IDB write failed.', e));
+}, 400);
 
-// Opens the verse modal with "About this page" guidance for the Notes page.
+// Opens the "About this page" info modal for the Notes page, via the shared
+// info-modal system (modals.js) — matches openNotesInfo()'s pattern for the
+// chapter-level Notes field info popup, rather than hijacking the verse
+// modal's DOM elements to show unrelated content.
 function openNotesPageInfo() {
-  const modalRef = document.getElementById('verseModalRef');
-  modalRef.textContent  = t('progress_notes_info_title');
-  modalRef.style.fontFamily = 'var(--font-stack-heading)';
-  document.getElementById('verseModalText').innerHTML = t('progress_notes_info_body');
-  document.getElementById('verseModalFooter').innerHTML = '';
-  document.getElementById('verseModalOverlay').classList.add('open');
+  openInfoModal(
+    'notes-page',
+    {
+      title: t('progress_notes_info_title'),
+      body:  t('progress_notes_info_body'),
+    },
+    null   // no trigger button — called directly, not from a ⓘ icon
+  );
 }
 
 // ── RENDER MENU ──────────────────────────────────────────────────────────────

--- a/app/js/save.js
+++ b/app/js/save.js
@@ -58,11 +58,11 @@ async function saveAnswers(isManual = true) {
 // Track progress as user types.
 // Debounced at 200ms so querySelectorAll and the DOM write in updateProgress()
 // run at most once per 200ms burst of keystrokes rather than on every character.
-let _updateProgressTimer = null;
+// Uses the shared debounce() helper from search.js instead of a hand-rolled timer.
+const _debouncedUpdateProgress = debounce(updateProgress, 200);
 document.addEventListener('input', e => {
   if (e.target.classList.contains('answer-field')) {
-    clearTimeout(_updateProgressTimer);
-    _updateProgressTimer = setTimeout(updateProgress, 200);
+    _debouncedUpdateProgress();
   }
 });
 

--- a/app/js/validation.js
+++ b/app/js/validation.js
@@ -595,7 +595,7 @@ function _appendTurn(thread, role, text) {
   body.className = 'ai-tutor-turn-body';
   // Render double-newlines as paragraph breaks
   body.innerHTML = text.split(/\n\n+/).map(p =>
-    '<p>' + _escHtml(p.trim()) + '</p>'
+    '<p>' + escapeHtml(p.trim()) + '</p>'
   ).join('');
 
   div.appendChild(label);
@@ -1015,10 +1015,3 @@ function _stripHtml(html) {
   return (tmp.textContent || tmp.innerText || '').trim();
 }
 
-function _escHtml(str) {
-  return str
-    .replace(/&/g,  '&amp;')
-    .replace(/</g,  '&lt;')
-    .replace(/>/g,  '&gt;')
-    .replace(/"/g,  '&quot;');
-}


### PR DESCRIPTION
## Summary
Four reuse fixes, plus one real bug found along the way:

- **validation.js** — `_escHtml()` reimplemented HTML escaping and was missing the single-quote escape `utils.js`'s `escapeHtml()` already has. Removed it (one call site, in the AI Tutor chat rendering) in favor of the existing `escapeHtml()`.
- **modals.js — real bug fix**: found while touching this code. `openInfoModal()` unconditionally did `_currentInfoTriggerBtn._infoId = infoId`, which throws `TypeError: Cannot set properties of null` when called with `triggerBtn = null` — which `openNotesInfo()` (a real, wired-up button: the chapter Notes field's ⓘ info icon) does on every call. `closeInfoModal()` already only reads `_infoId` when `_currentInfoTriggerBtn` is truthy, so the fix is just a guard before the assignment. Verified with a Node simulation that the null-trigger call path no longer throws and the normal (button) path still tags the button correctly.
- **render-library.js** — `libPathDownload()` built a toast by hand (`textContent` + `classList` + a bare `setTimeout`) instead of calling `showToast()`, missing its hide-timer/reset-text bookkeeping and dismiss-on-outside-tap behavior.
- **render-progress.js** — `openNotesPageInfo()` hijacked the verse modal's DOM elements (`verseModalRef`/`Text`/`Footer`/`Overlay`) to show unrelated "about this page" content, using raw `innerHTML` instead of the sanitizing `safeSetHtml()`. Now routes through `openInfoModal()`, matching `openNotesInfo()`'s existing pattern for the analogous chapter-level Notes info popup — and picks up the `openInfoModal()` bug fix above for free.
- **save.js + render-progress.js** — both hand-rolled the same `clearTimeout`/`setTimeout` debounce pattern (for `updateProgress()` and `_saveGlobalNotes()` respectively) instead of reusing the `debounce()` helper already defined in `search.js`.

## Verification
No automated test suite exists in this repo. Verified the `openInfoModal()` fix and the `debounce()` substitution with isolated Node simulations (see conversation) — confirmed the null-trigger path no longer throws, the button-trigger path is unaffected, and the debounced wrapper correctly coalesces rapid calls into one with the last call's arguments. All 5 touched files pass `node --check`.

## Test plan
- [ ] Tap the chapter Notes field's ⓘ info icon — this was silently broken before; confirm the info popup now opens correctly.
- [ ] Progress → Notes page → tap "About this page" — confirm the info modal opens with correct title/body and closes normally.
- [ ] Library → a Path with a placeholder/missing download link → tap download — confirm the "coming soon" toast still appears and behaves normally (including tapping away to dismiss early).
- [ ] Type in an answer field — progress ring/checkmarks still update after a short pause, not on every keystroke.
- [ ] Type in the global Notes textarea — content still saves after a short pause.
- [ ] Trigger an AI Tutor response containing a quote or special character — confirm it renders correctly, no broken HTML.