### PR TITLE
Dedupe near-identical code, remove dead code, fix pinned-reorder bug

### DIFF
--- a/app/js/modals.js
+++ b/app/js/modals.js
@@ -269,12 +269,11 @@ function renderLikertScale(el, chNum, chapterAnswers = null) {
 //   • Clicking a tab updates the ref display, passage text, speak button, and
 //     external link — no modal close/reopen needed.
 
-function openVerseModal(ref) {
-  const raw = verseData[ref];
-  if (!raw) return;
-
-  // ── Normalise legacy v1 shape → v2 shape ─────────────────────────────────
-  const data = raw.translations
+// Normalises a verseData[ref] entry to the v2 { translations: [...] } shape.
+// Legacy v1 entries carry { text, netUrl, translation } directly instead.
+// Shared by openVerseModal and switchVerseTranslation.
+function _normalizeVerseData(raw, ref) {
+  return raw.translations
     ? raw
     : {
         translations: [{
@@ -284,7 +283,13 @@ function openVerseModal(ref) {
           ref:   ref,
         }],
       };
+}
 
+function openVerseModal(ref) {
+  const raw = verseData[ref];
+  if (!raw) return;
+
+  const data = _normalizeVerseData(raw, ref);
   if (!data.translations.length) return;
 
   // ── Resolve the active translation ────────────────────────────────────────
@@ -311,17 +316,9 @@ function openVerseModal(ref) {
   const tabRowEl = document.getElementById('verseModalTabRow');
   if (tabRowEl) tabRowEl.innerHTML = tabRowHtml;
 
-  document.getElementById('verseModalRef').textContent   = activeTrans.ref || ref;
-  safeSetHtml('verseModalText', activeTrans.text);
-  safeSetHtml('verseModalFooter',
-    activeTrans.url
-      ? `(<a href="${_safeUrl(activeTrans.url)}" target="_blank">${t('modals_verse_net_link')}</a>)`
-      : '');
+  _renderVerseTranslation(activeTrans, ref);
 
   document.getElementById('verseModalOverlay').classList.add('open');
-
-  // ── Wire speak button ─────────────────────────────────────────────────────
-  _wireVerseModalSpeak(activeTrans.text);
 }
 
 // Switches the active translation tab without closing/reopening the modal.
@@ -333,10 +330,7 @@ function switchVerseTranslation(ref, label) {
   const raw = verseData[ref];
   if (!raw) return;
 
-  const data = raw.translations
-    ? raw
-    : { translations: [{ label: raw.translation || 'NET', text: raw.text, url: raw.netUrl, ref }] };
-
+  const data = _normalizeVerseData(raw, ref);
   const tr = data.translations.find(t => t.label === label);
   if (!tr) return;
 
@@ -348,21 +342,25 @@ function switchVerseTranslation(ref, label) {
     btn.classList.toggle('active', btn.textContent.trim() === label);
   });
 
-  // Update ref, text, footer link.
-  document.getElementById('verseModalRef').textContent  = tr.ref || ref;
+  _renderVerseTranslation(tr, ref);
+}
+
+// Internal helper: populates the ref/text/footer link and re-wires the speak
+// button for a single translation. Shared by openVerseModal and
+// switchVerseTranslation so the _safeUrl() sanitization and footer-link
+// markup live in exactly one place.
+function _renderVerseTranslation(tr, ref) {
+  document.getElementById('verseModalRef').textContent = tr.ref || ref;
   safeSetHtml('verseModalText', tr.text);
   safeSetHtml('verseModalFooter',
     tr.url
       ? `(<a href="${_safeUrl(tr.url)}" target="_blank">${t('modals_verse_net_link')}</a>)`
       : '');
-
-  // Re-wire the speak button to the new translation's text.
   _wireVerseModalSpeak(tr.text);
 }
 
 // Internal helper: sets the speak button's visibility and onclick for the
-// currently displayed translation text. Extracted to avoid repetition between
-// openVerseModal and switchVerseTranslation.
+// currently displayed translation text.
 function _wireVerseModalSpeak(text) {
   const vsb = document.getElementById('verseModalSpeakBtn');
   if (!vsb) return;

--- a/app/js/navigation.js
+++ b/app/js/navigation.js
@@ -63,18 +63,6 @@ function _resetNonChapterPageState() {
   touchstartX = touchendX; // neutralise any in-flight swipe from the closing gesture
 }
 
-// Closes the menu drawer and renders the title page.
-function goToTitlePage() {
-  closeMenu();
-  Router.navigate({ page: 'title' });
-}
-
-// Closes the menu drawer and navigates to the copyright/licence page.
-function goToCopyright() {
-  closeMenu();
-  Router.navigate({ page: 'about', tabId: 'copyright' });
-}
-
 // Toggles the chapter menu drawer open/closed and updates the hamburger button.
 // Re-renders the menu list each time it opens to refresh progress checkmarks.
 // Closes the search overlay first if it happens to be open.

--- a/app/js/onboarding.js
+++ b/app/js/onboarding.js
@@ -920,16 +920,8 @@ function updateNavButtons() {
 // NAV CLICK HANDLERS
 // ══════════════════════════════════════════════════════════════════════════════
 
-function navLibClick() {
-  if (window.activeTabPage === 'library') { Router.back(); } else { Router.navigate({ page: 'library' }); }
-}
+// navLibClick/navProgressClick/navHowtoClick/navSettingsClick are defined in
+// router.js, not here — router.js loads after onboarding.js specifically so
+// its Router-aware versions are the ones that end up live (see the comment
+// there). Only navSearchClick has no router.js counterpart, so it stays.
 function navSearchClick()   { openSearch(); }
-function navProgressClick() {
-  if (window.activeTabPage === 'progress') { Router.back(); } else { Router.navigate({ page: 'progress' }); }
-}
-function navHowtoClick() {
-  if (window.activeTabPage === 'howto') { Router.back(); } else { Router.navigate({ page: 'howto' }); }
-}
-function navSettingsClick() {
-  if (window.activeTabPage === 'settings') { Router.back(); } else { Router.navigate({ page: 'settings' }); }
-}

--- a/app/js/render-library.js
+++ b/app/js/render-library.js
@@ -238,16 +238,37 @@ function setLibLangFilter(langCode) {
 let reorderActiveId = null;
 let cardLongPressTimer = null;
 
-// Swap study at position idx with its neighbour (direction: -1=up, +1=down),
-// persist to localStorage, and re-render the library.
+// Swap study at position idx with its neighbour WITHIN THE SAME pinned/unpinned
+// section (direction: -1=up, +1=down), persist to localStorage, and re-render
+// the library. Mirrors moveRecentStudy()'s subset-based approach above — a
+// bare swap of adjacent entries in the flat registry doesn't correspond to
+// the visual reorder within the Pinned/All sections whenever pinned studies
+// aren't contiguous in the registry (e.g. pin studies B and D out of
+// A,B,C,D: moving B down swapped registry positions 1 and 2 — B and C — so
+// the Pinned section, still [B, D] afterward, never visibly reordered).
 function moveStudy(id, direction) {
-  const registry = JSON.parse(localStorage.getItem('study_registry') || '[]');
-  const idx = registry.indexOf(id);
+  const registry  = JSON.parse(localStorage.getItem('study_registry') || '[]');
+  const pinnedAll = getPinnedAll();
+  const isPinned  = pinnedAll.includes(id);
+
+  // Build the sub-list of studies in the same section (pinned or unpinned)
+  const subList = registry.filter(x => isPinned ? pinnedAll.includes(x) : !pinnedAll.includes(x));
+  const idx = subList.indexOf(id);
   if (idx === -1) return;
   const newIdx = idx + direction;
-  if (newIdx < 0 || newIdx >= registry.length) return;
-  [registry[idx], registry[newIdx]] = [registry[newIdx], registry[idx]];
-  safeSetItem('study_registry', JSON.stringify(registry));
+  if (newIdx < 0 || newIdx >= subList.length) return;
+
+  // Swap within sub-list
+  [subList[idx], subList[newIdx]] = [subList[newIdx], subList[idx]];
+
+  // Reconstruct the full registry with corrected relative order
+  let si = 0;
+  const newRegistry = registry.map(x => {
+    const xPinned = pinnedAll.includes(x);
+    if (xPinned === isPinned) return subList[si++];
+    return x;
+  });
+  safeSetItem('study_registry', JSON.stringify(newRegistry));
   renderLibrary(); // re-render; enterReorderMode called inside to keep state
 }
 
@@ -310,6 +331,81 @@ function attachCardLongPress(card, id) {
     clearTimeout(cardLongPressTimer);
     cardLongPressTimer = null;
   }, { passive: true });
+}
+
+// Builds a single study card element for the Load/All or Recent tab's
+// pinned/unpinned sections. Shared by buildAllTab() and buildRecentTab()
+// inside renderLibrary() — the two previously carried near-identical ~60-line
+// copies of this, differing only in which move/pin functions they wired up.
+//
+// entry    – the studyCache[id] entry (title, subtitle, cover, etc.)
+// listIds  – the pinned or unpinned id list this card belongs to, used to
+//            compute whether the reorder arrows should be disabled at the
+//            ends of that list.
+// moveFn   – name of the global function to call for the reorder arrows,
+//            e.g. 'moveStudy' or 'moveRecentStudy'. Passed as a string since
+//            it's embedded directly into an onclick="" attribute.
+// toggleFn – name of the global function to call for the pin button, e.g.
+//            'togglePinAll' or 'togglePin'.
+function _buildStudyCard(id, entry, listIds, isPinned, moveFn, toggleFn) {
+  const e = entry;
+  const isReorderActive = (reorderActiveId === id);
+  const idxInList = listIds.indexOf(id);
+  const isFirst = idxInList === 0;
+  const isLast  = idxInList === listIds.length - 1;
+  const pinClass = isPinned ? 'lib-pin-btn pinned' : 'lib-pin-btn';
+
+  // Reorder arrows (long-press) or delete button
+  const reorderHtml = isReorderActive
+    ? `<div class="study-card-reorder-btns" onclick="event.stopPropagation()">
+         <button class="study-card-reorder-btn"
+           ${isFirst ? 'disabled' : ''}
+           onclick="event.stopPropagation(); ${moveFn}('${id}', -1)"
+           title="${t('renderlib_move_up')}"
+           aria-label="${t('renderlib_move_up')}">${ICONS.arrowUp}</button>
+         <button class="study-card-reorder-btn"
+           ${isLast ? 'disabled' : ''}
+           onclick="event.stopPropagation(); ${moveFn}('${id}', 1)"
+           title="${t('renderlib_move_down')}"
+           aria-label="${t('renderlib_move_down')}">${ICONS.arrowDown}</button>
+       </div>`
+    : `<button class="study-card-delete-btn"
+         onclick="event.stopPropagation(); deleteStudy('${id}', '${escapeHtml(e.title)}')"
+         style="background:none; border:none; padding:10px; font-size:18px; cursor:pointer; opacity:0.6; z-index:2; margin-left: 4px;">
+         ${ICONS.trash}
+       </button>`;
+
+  const card = document.createElement('div');
+  card.className = 'study-card' + (isReorderActive ? ' study-card--reorder-active' : '');
+  card.dataset.studyId = id;
+
+  card.onclick = () => {
+    if (card._suppressNextClick) { card._suppressNextClick = false; return; }
+    if (isReorderActive) return;
+    activateStudy(id);
+  };
+
+  const coverHtml = e.coverSrc
+    ? `<img class="study-card-cover" src="${e.coverSrc}" alt=""
+           onerror="this.style.display='none';this.nextElementSibling.style.display='flex';">
+       <div class="study-card-cover-fallback" style="display:none">${escapeHtml(e.fallback)}</div>`
+    : `<div class="study-card-cover-fallback">${escapeHtml(e.fallback)}</div>`;
+
+  card.innerHTML = `
+    <button class="${pinClass}"
+      onclick="event.stopPropagation(); ${toggleFn}('${id}')"
+      title="${isPinned ? t('renderlib_unpin') : t('renderlib_pin_to_top')}">${isPinned ? ICONS.pinFilled : ICONS.pin}</button>
+    ${coverHtml}
+
+    <div class="study-card-text" style="flex:1;">
+      <h3>${escapeHtml(e.title)}</h3>
+      ${e.subtitle ? `<div class="study-card-subtitle">${escapeHtml(e.subtitle)}</div>` : ''}
+      ${studyLangBadgesHtml(e.meta)}
+    </div>
+    ${reorderHtml}`;
+
+  attachCardLongPress(card, id);
+  return card;
 }
 
 async function renderLibrary() {
@@ -562,67 +658,8 @@ async function renderLibrary() {
     const pinnedIds   = registry.filter(id => pinnedAll.includes(id)  && studyCache[id] && studyMatchesLangFilter(studyCache[id]));
     const unpinnedIds = registry.filter(id => !pinnedAll.includes(id) && studyCache[id] && studyMatchesLangFilter(studyCache[id]));
 
-    function buildAllRow(id, listIds, isPinned) {
-      const e = studyCache[id];
-      const isReorderActive = (reorderActiveId === id);
-      const idxInList = listIds.indexOf(id);
-      const isFirst = idxInList === 0;
-      const isLast  = idxInList === listIds.length - 1;
-      const pinClass = isPinned ? 'lib-pin-btn pinned' : 'lib-pin-btn';
-
-      // Reorder arrows (long-press) or delete button
-      const reorderHtml = isReorderActive
-        ? `<div class="study-card-reorder-btns" onclick="event.stopPropagation()">
-             <button class="study-card-reorder-btn"
-               ${isFirst ? 'disabled' : ''}
-               onclick="event.stopPropagation(); moveStudy('${id}', -1)"
-               title="${t('renderlib_move_up')}"
-               aria-label="${t('renderlib_move_up')}">${ICONS.arrowUp}</button>
-             <button class="study-card-reorder-btn"
-               ${isLast ? 'disabled' : ''}
-               onclick="event.stopPropagation(); moveStudy('${id}', 1)"
-               title="${t('renderlib_move_down')}"
-               aria-label="${t('renderlib_move_down')}">${ICONS.arrowDown}</button>
-           </div>`
-        : `<button class="study-card-delete-btn"
-             onclick="event.stopPropagation(); deleteStudy('${id}', '${escapeHtml(e.title)}')"
-             style="background:none; border:none; padding:10px; font-size:18px; cursor:pointer; opacity:0.6; z-index:2; margin-left: 4px;">
-             ${ICONS.trash}
-           </button>`;
-
-      //"bluefish color-coding (6)
-      const card = document.createElement('div');
-      card.className = 'study-card' + (isReorderActive ? ' study-card--reorder-active' : '');
-      card.dataset.studyId = id;
-
-      card.onclick = () => {
-        if (card._suppressNextClick) { card._suppressNextClick = false; return; }
-        if (isReorderActive) return;
-        activateStudy(id);
-      };
-
-      const coverHtml = e.coverSrc
-        ? `<img class="study-card-cover" src="${e.coverSrc}" alt=""
-               onerror="this.style.display='none';this.nextElementSibling.style.display='flex';">
-           <div class="study-card-cover-fallback" style="display:none">${escapeHtml(e.fallback)}</div>`
-        : `<div class="study-card-cover-fallback">${escapeHtml(e.fallback)}</div>`;
-
-      card.innerHTML = `
-        <button class="${pinClass}"
-          onclick="event.stopPropagation(); togglePinAll('${id}')"
-          title="${isPinned ? t('renderlib_unpin') : t('renderlib_pin_to_top')}">${isPinned ? ICONS.pinFilled : ICONS.pin}</button>
-        ${coverHtml}
-
-        <div class="study-card-text" style="flex:1;">
-          <h3>${escapeHtml(e.title)}</h3>
-          ${e.subtitle ? `<div class="study-card-subtitle">${escapeHtml(e.subtitle)}</div>` : ''}
-          ${studyLangBadgesHtml(e.meta)}
-        </div>
-        ${reorderHtml}`;
-
-      attachCardLongPress(card, id);
-      return card;
-    }
+    const buildAllRow = (id, listIds, isPinned) =>
+      _buildStudyCard(id, studyCache[id], listIds, isPinned, 'moveStudy', 'togglePinAll');
 
     const frag = document.createDocumentFragment();
 
@@ -668,67 +705,8 @@ async function renderLibrary() {
     const pinnedIds   = opened.filter(id => pinned.includes(id));
     const unpinnedIds = opened.filter(id => !pinned.includes(id));
 
-    function buildRecentRow(id, listIds, isPinned) {
-      const e = studyCache[id];
-      const isReorderActive = (reorderActiveId === id);
-      const idxInList = listIds.indexOf(id);
-      const isFirst = idxInList === 0;
-      const isLast  = idxInList === listIds.length - 1;
-
-      const pinClass = isPinned ? 'lib-pin-btn pinned' : 'lib-pin-btn';
-
-      const reorderHtml = isReorderActive
-        ? `<div class="study-card-reorder-btns" onclick="event.stopPropagation()">
-             <button class="study-card-reorder-btn"
-               ${isFirst ? 'disabled' : ''}
-               onclick="event.stopPropagation(); moveRecentStudy('${id}', -1)"
-               title="${t('renderlib_move_up')}"
-               aria-label="${t('renderlib_move_up')}">${ICONS.arrowUp}</button>
-             <button class="study-card-reorder-btn"
-               ${isLast ? 'disabled' : ''}
-               onclick="event.stopPropagation(); moveRecentStudy('${id}', 1)"
-               title="${t('renderlib_move_down')}"
-               aria-label="${t('renderlib_move_down')}">${ICONS.arrowDown}</button>
-           </div>`
-        : `<button class="study-card-delete-btn"
-             onclick="event.stopPropagation(); deleteStudy('${id}', '${escapeHtml(e.title)}')"
-             style="background:none; border:none; padding:10px; font-size:18px; cursor:pointer; opacity:0.6; z-index:2; margin-left: 4px;">
-             ${ICONS.trash}
-           </button>`;
-
-      //"bluefish color-coding (5)
-      const card = document.createElement('div');
-      card.className = 'study-card' + (isReorderActive ? ' study-card--reorder-active' : '');
-      card.dataset.studyId = id;
-
-      card.onclick = () => {
-        if (card._suppressNextClick) { card._suppressNextClick = false; return; }
-        if (isReorderActive) return;
-        activateStudy(id);
-      };
-
-      const coverHtml = e.coverSrc
-        ? `<img class="study-card-cover" src="${e.coverSrc}" alt=""
-               onerror="this.style.display='none';this.nextElementSibling.style.display='flex';">
-           <div class="study-card-cover-fallback" style="display:none">${escapeHtml(e.fallback)}</div>`
-        : `<div class="study-card-cover-fallback">${escapeHtml(e.fallback)}</div>`;
-
-      card.innerHTML = `
-        <button class="${pinClass}"
-          onclick="event.stopPropagation(); togglePin('${id}')"
-          title="${isPinned ? t('renderlib_unpin') : t('renderlib_pin_to_top')}">${isPinned ? ICONS.pinFilled : ICONS.pin}</button>
-        ${coverHtml}
-
-        <div class="study-card-text" style="flex:1;">
-          <h3>${escapeHtml(e.title)}</h3>
-          ${e.subtitle ? `<div class="study-card-subtitle">${escapeHtml(e.subtitle)}</div>` : ''}
-          ${studyLangBadgesHtml(e.meta)}
-        </div>
-        ${reorderHtml}`;
-
-      attachCardLongPress(card, id);
-      return card;
-    }
+    const buildRecentRow = (id, listIds, isPinned) =>
+      _buildStudyCard(id, studyCache[id], listIds, isPinned, 'moveRecentStudy', 'togglePin');
 
     // Build DOM fragment
     const frag = document.createDocumentFragment();

--- a/app/js/render-progress.js
+++ b/app/js/render-progress.js
@@ -36,14 +36,6 @@ function getActivePathway() {
   return { ...l2Item, _l1Title: l1Item.titleLevel1, _key: key };
 }
 
-// Sets the active pathway in localStorage and re-renders the progress page
-// so the tab bar appears immediately after selection.
-function setActivePathway(l1Idx, l2Idx) {
-  safeSetItem('bsr_activePathwayId', `${l1Idx}_${l2Idx}`);
-  Router.replaceState({ page: 'progress' });
-  renderProgressOverview();
-}
-
 // Clears the active pathway and re-renders.
 function clearActivePathway() {
   localStorage.removeItem('bsr_activePathwayId');

--- a/app/js/router.js
+++ b/app/js/router.js
@@ -534,31 +534,23 @@ const Router = (() => {
 })();
 
 
-// ── UPDATED nav click handlers (replace the versions in onboarding.js) ────────
+// ── Nav click handlers ──────────────────────────────────────────────────────
 //
-// The toggle logic is now:
-//   - If already on the page → history.back() (keeps the stack clean)
-//   - Otherwise → Router.navigate(...)
-//
-// These are reassigned here so they overwrite the originals once router.js
-// loads. Place router.js AFTER onboarding.js in your script load order.
+// Toggle logic: if already on the page → history.back() (keeps the stack
+// clean); otherwise → Router.navigate(...). One factory generates all four
+// named handlers instead of repeating the same toggle four times. Assigned
+// via window.* (rather than plain function declarations) so they're
+// reachable the same way as the equivalent pattern used elsewhere in this
+// codebase for anything called from an inline onclick="" attribute.
 
-function navLibClick() {
-  if (window.activeTabPage === 'library') { Router.back(); }
-  else { Router.navigate({ page: 'library' }); }
+function _makeNavClick(page) {
+  return function() {
+    if (window.activeTabPage === page) Router.back();
+    else Router.navigate({ page });
+  };
 }
 
-function navProgressClick() {
-  if (window.activeTabPage === 'progress') { Router.back(); }
-  else { Router.navigate({ page: 'progress' }); }
-}
-
-function navHowtoClick() {
-  if (window.activeTabPage === 'howto') { Router.back(); }
-  else { Router.navigate({ page: 'howto' }); }
-}
-
-function navSettingsClick() {
-  if (window.activeTabPage === 'settings') { Router.back(); }
-  else { Router.navigate({ page: 'settings' }); }
-}
+window.navLibClick      = _makeNavClick('library');
+window.navProgressClick = _makeNavClick('progress');
+window.navHowtoClick    = _makeNavClick('howto');
+window.navSettingsClick = _makeNavClick('settings');


### PR DESCRIPTION
## Summary

- **router.js / onboarding.js** — `navLibClick`/`navProgressClick`/`navHowtoClick`/`navSettingsClick` were defined twice: once in `onboarding.js`, once in `router.js`. Since `onboarding.js` loads first, its four copies were always immediately shadowed by `router.js`'s (confirmed dead code, not a behavior change — same outcome either way). Removed the `onboarding.js` copies (`navSearchClick`, which has no `router.js` counterpart, stays) and collapsed `router.js`'s four near-identical functions into one factory.
- **modals.js** — `openVerseModal()` and `switchVerseTranslation()` each normalized the legacy `verseData` shape and populated ref/text/footer/speak-button with near-duplicate code, including two copies of the `_safeUrl()` sanitization for the footer link. Extracted `_normalizeVerseData()` and `_renderVerseTranslation()`, shared by both.
- **render-library.js** — `buildAllRow()` and `buildRecentRow()` were ~60-line near-identical study-card builders differing only in which move/pin functions they wired up. Extracted a shared `_buildStudyCard(id, entry, listIds, isPinned, moveFn, toggleFn)`.
- **render-library.js — real bug fix found while doing the above**: `moveStudy()` swapped adjacent entries in the flat `study_registry` array, but the Pinned section's reorder arrows are enabled/disabled based on position within the *pinned* subset. Whenever pinned studies weren't contiguous in the registry, tapping an arrow swapped a pinned study with an unpinned neighbour instead of the next pinned study, so the Pinned section didn't visibly reorder. Rewrote `moveStudy()` to operate on the pinned/unpinned subset, mirroring `moveRecentStudy()`'s already-correct approach. Verified with a Node simulation reproducing the exact scenario from the original review (registry `[A,B,C,D]`, pin B and D, move B down — now correctly reorders to `[D,B]`).
- **navigation.js** — removed `goToTitlePage()`/`goToCopyright()` — zero call sites anywhere.
- **render-progress.js** — removed `setActivePathway(l1Idx, l2Idx)` — zero call sites; the active pathway is set via `libPathSetActive()` in `render-library.js` (a different signature/toggle behavior for a different UI context, not a good fit to merge) and cleared via the still-used `clearActivePathway()`.

## Verification
No automated test suite exists in this repo. Verified with isolated Node simulations (see conversation): the `moveStudy()` fix reproduces and correctly resolves the exact pinned-reorder bug scenario, and the `router.js` nav-click factory produces identical behavior to the four original functions across both the "already on page → back()" and "navigate to page" branches. All 6 touched files pass `node --check`, and a full-codebase grep confirms zero remaining references to any of the removed identifiers.

## Test plan
- [ ] Bottom nav: tap Library/Progress/How To/Settings from various starting pages — confirm toggle-to-back behavior still works identically.
- [ ] Tap a Bible verse reference to open the verse modal, then switch between translation tabs (for a passage with multiple translations) — confirm ref/text/footer link/speak button all update correctly.
- [ ] Library "All" tab: pin 2+ non-adjacent studies (e.g. pin the 1st and 3rd of 4 installed studies), long-press to enter reorder mode, tap the arrows — confirm the Pinned section now visibly reorders correctly.
- [ ] Library "Recent" tab reorder — confirm unaffected (already used the correct subset-based logic).
- [ ] App onboarding slides (first run or via HowTo → "View app slides again") — confirm still plays through normally.