### PR TITLE
Consolidate language-slot resolution; fix AI Tutor context bug

### DIFF
--- a/app/js/render-chapter-elements.js
+++ b/app/js/render-chapter-elements.js
@@ -165,6 +165,28 @@ function resolveMetaField(obj, field, lang, langMap) {
 }
 
 
+// resolveTextWithFallback(el, lang, field, langMap, fallback)
+//
+// Like resolveText(), but for callers that also want to fall back to the
+// plain unnumbered field when the resolved language slot is missing —
+// not just slot 1. resolveText()'s own multilingual path deliberately stops
+// at slot 1 (existing callers rely on strict numbered-slot resolution), so
+// this variant lives separately rather than changing resolveText() itself.
+//
+// Used for chapter titles (buildNavButtons() in render-chapter-ui.js and the
+// chapter header in render-chapter.js both need this exact fallback chain),
+// and anywhere else that wants "numbered slot → slot 1 → unnumbered → fallback".
+
+function resolveTextWithFallback(el, lang, field, langMap, fallback = '') {
+  if (langMap && Object.keys(langMap).length > 0) {
+    const slot = langMap[lang];
+    if (slot !== undefined) return el[`${field}${slot}`] || el[`${field}1`] || el[field] || fallback;
+    return el[`${field}1`] || el[field] || fallback;
+  }
+  return el[field] || fallback;
+}
+
+
 // ── BIBLE TRANSLATION RESOLUTION ─────────────────────────────────────────────
 // resolveBibleTranslation(slotIndex, studyMetadata)
 //

--- a/app/js/render-chapter-ui.js
+++ b/app/js/render-chapter-ui.js
@@ -176,14 +176,7 @@ function buildNavButtons(idx, activeLang, langMap) {
   if (!appSettings.showNavButtons) return '';
 
   function resolveChapterTitle(ch) {
-    if (langMap && Object.keys(langMap).length > 0) {
-      const slot = langMap[activeLang];
-      if (slot !== undefined) {
-        return ch[`chapterTitle${slot}`] || ch[`chapterTitle1`] || ch.chapterTitle || '';
-      }
-      return ch[`chapterTitle1`] || ch.chapterTitle || '';
-    }
-    return ch.chapterTitle || '';
+    return resolveTextWithFallback(ch, activeLang, 'chapterTitle', langMap);
   }
 
   const showBack = idx > 0;

--- a/app/js/render-chapter.js
+++ b/app/js/render-chapter.js
@@ -145,14 +145,7 @@ async function renderChapter(idx, scrollY = 0) {
     // ── Resolve the chapter title for the active language ─────────────────────
     // Multilingual studies store chapterTitle1/chapterTitle2/chapterTitle3.
     // Mono-lingual studies store chapterTitle (unnumbered).
-    const chapterTitle = (() => {
-      if (langMap && Object.keys(langMap).length > 0) {
-        const slot = langMap[activeLang];
-        if (slot !== undefined) return ch[`chapterTitle${slot}`] || ch[`chapterTitle1`] || ch.chapterTitle || '';
-        return ch[`chapterTitle1`] || ch.chapterTitle || '';
-      }
-      return ch.chapterTitle || '';
-    })();
+    const chapterTitle = resolveTextWithFallback(ch, activeLang, 'chapterTitle', langMap);
 
     // ── elementId → element map for resolving repeatElement references ────────
     const elementMap = {};

--- a/app/js/study-loader.js
+++ b/app/js/study-loader.js
@@ -559,22 +559,25 @@ async function applyStudyData(data, { isStudySwitch = false, silent = false } = 
   const _activeSlot   = _langMap[_activeLang] || 1;
   const _isMultilang  = Object.keys(_langMap).length > 0;
 
-  // ── Helper: resolve a numbered metadata field ──────────────────────────────
+  // ── Helper: resolve a numbered field on any plain object ───────────────────
   // Priority (multilingual):
-  //   1. metadata[field + activeSlot]   — active language
-  //   2. metadata[field + '1']          — slot-1 fallback
-  //   3. metadata[field]                — unnumbered (mono-lingual)
+  //   1. obj[field + activeSlot]   — active language
+  //   2. obj[field + '1']          — slot-1 fallback
+  //   3. obj[field]                — unnumbered (mono-lingual)
   //   4. fallback string
   // For mono-lingual studies (no languageN keys) falls straight through to
   // the unnumbered field, preserving full backward compatibility.
-  function _resolveMeta(field, fallback = '') {
+  // Used below for studyMetadata fields, onboarding slide fields, and slide
+  // action labels — all three previously wrote out this exact same algorithm
+  // separately.
+  function _resolveNumberedField(obj, field, fallback = '') {
     if (_isMultilang) {
-      return metadata[`${field}${_activeSlot}`]
-          || metadata[`${field}1`]
-          || metadata[field]
+      return obj[`${field}${_activeSlot}`]
+          || obj[`${field}1`]
+          || obj[field]
           || fallback;
     }
-    return metadata[field] || fallback;
+    return obj[field] || fallback;
   }
 
   // ── Normalise title / subtitle / shortTitle onto studyMetadata ────────────
@@ -583,8 +586,8 @@ async function applyStudyData(data, { isStudySwitch = false, silent = false } = 
   // so nothing else needs to know about the numbered schema.
   //
   // shortTitle priority: shortTitle1 > shortTitle (unnumbered) > title slot > 'Study'
-  const resolvedTitle    = _resolveMeta('title',    'Untitled Study');
-  const resolvedSubtitle = _resolveMeta('subtitle', '');
+  const resolvedTitle    = _resolveNumberedField(metadata, 'title',    'Untitled Study');
+  const resolvedSubtitle = _resolveNumberedField(metadata, 'subtitle', '');
   const resolvedShortTitle = (() => {
     // shortTitle1 always wins when present (multilingual canonical).
     if (_isMultilang && metadata.shortTitle1) {
@@ -606,37 +609,23 @@ async function applyStudyData(data, { isStudySwitch = false, silent = false } = 
   // and action.label as label1/label2/label3.
   // We resolve every field to a plain string here, at load time, so
   // showSlideOverlay() can stay format-agnostic (it always reads s.eyebrow etc).
-  // Mono-lingual slides already carry plain unnumbered fields — _resolveMeta
-  // logic is applied per-field so both shapes work transparently.
+  // Mono-lingual slides already carry plain unnumbered fields —
+  // _resolveNumberedField logic is applied per-field so both shapes work
+  // transparently.
   studyOnboardingSlides = (data.studyOnboardingSlides || []).map(slide => {
-    // Resolve each text field: numbered slot wins over unnumbered fallback.
-    function _resolveSlideField(field) {
-      if (_isMultilang) {
-        return slide[`${field}${_activeSlot}`]
-            || slide[`${field}1`]
-            || slide[field]
-            || '';
-      }
-      return slide[field] || '';
-    }
-
     const resolved = {
       ...slide,
-      eyebrow:   _resolveSlideField('eyebrow'),
-      heading:   _resolveSlideField('heading'),
-      body:      _resolveSlideField('body'),
-      bodyAfter: _resolveSlideField('bodyAfter'),
+      eyebrow:   _resolveNumberedField(slide, 'eyebrow'),
+      heading:   _resolveNumberedField(slide, 'heading'),
+      body:      _resolveNumberedField(slide, 'body'),
+      bodyAfter: _resolveNumberedField(slide, 'bodyAfter'),
     };
 
     // Resolve action if present.
     if (slide.action) {
       // label is now numbered (label1/label2/label3); fall back to plain label.
-      const resolvedLabel = _isMultilang
-        ? (slide.action[`label${_activeSlot}`] || slide.action.label1 || slide.action.label || '')
-        : (slide.action.label || '');
-
       resolved.action = {
-        label: resolvedLabel,
+        label: _resolveNumberedField(slide.action, 'label'),
         fn:    slide.action.fn === null ? resolveActionFn(slide.action) : slide.action.fn,
       };
     }

--- a/app/js/validation.js
+++ b/app/js/validation.js
@@ -553,24 +553,39 @@ function _getQuestionText(card) {
 }
 
 // Builds a compact context string from the chapter's leaders notes (if available).
+//
+// Multilingual studies store chapterTitle/keyPoints/pastorals as numbered
+// fields (chapterTitle1/2/3 etc.) — resolved here for the active language via
+// the same helpers render-pages.js's Leaders Notes page already uses for
+// keyPoints/pastorals, and render-chapter.js/render-chapter-ui.js already use
+// for chapter titles. Reading these fields unnumbered (the previous
+// behavior) is always undefined for a multilingual study, so this context
+// was silently empty in every AI Tutor prompt for any multilingual study.
 function _buildChapterContext(ch) {
   if (!ch) return 'No additional context available.';
 
   const lnd     = window.leadersNotesData || {};
   const chNotes = (lnd.chapters || []).find(c => c.chapterNumber === ch.chapterNumber);
 
+  const availableLangs = detectAvailableLangs();
+  const activeLang     = getActiveLang(availableLangs) || 'en';
+  const langMap        = buildLangMap(window.studyMetadata || {});
+
   const parts = [];
 
-  if (ch.chapterTitle) {
-    parts.push('Chapter: ' + ch.chapterTitle);
+  const chapterTitle = resolveTextWithFallback(ch, activeLang, 'chapterTitle', langMap);
+  if (chapterTitle) {
+    parts.push('Chapter: ' + chapterTitle);
   }
 
   if (chNotes) {
-    if (chNotes.keyPoints) {
-      parts.push('Key themes:\n' + _stripHtml(chNotes.keyPoints));
+    const keyPoints = resolveMetaField(chNotes, 'keyPoints', activeLang, langMap);
+    if (keyPoints) {
+      parts.push('Key themes:\n' + _stripHtml(keyPoints));
     }
-    if (chNotes.pastorals) {
-      parts.push('Pastoral context:\n' + _stripHtml(chNotes.pastorals));
+    const pastorals = resolveMetaField(chNotes, 'pastorals', activeLang, langMap);
+    if (pastorals) {
+      parts.push('Pastoral context:\n' + _stripHtml(pastorals));
     }
   }
 


### PR DESCRIPTION
## Summary

The "resolve a numbered field for the active language" algorithm (multilingual `.estudy` files store `title1/title2/title3` etc.) was reimplemented four separate times across the codebase, plus one place where it wasn't done at all — a real, previously-undiscovered bug.

- **render-chapter-elements.js** — added `resolveTextWithFallback()`, a variant of the existing `resolveText()`/`resolveMetaField()` that also falls back to the plain unnumbered field when the resolved slot is missing entirely. `resolveText()`'s own multilingual path deliberately stops at slot 1 (existing callers rely on that), so this lives as a separate function rather than changing `resolveText()` itself and risking every other caller of it.
- **render-chapter.js** and **render-chapter-ui.js** — both had a byte-identical chapter-title resolution block (the exact pattern above) duplicated inline. Both now call `resolveTextWithFallback()`.
- **study-loader.js**'s `applyStudyData()` wrote out this same "slot → slot1 → unnumbered → fallback" algorithm three separate times internally (`_resolveMeta` for metadata fields, `_resolveSlideField` for onboarding slide fields, and an inline ternary for slide action labels) — unified into one local `_resolveNumberedField(obj, field, fallback)` helper. **Deliberately not** switched to the shared `render-chapter-elements.js` helpers here: this file's own comment documents that its langMap-building loop is intentionally duplicated "so study-loader.js carries no dependency on render-elements.js" — an existing architectural boundary this PR respects rather than breaks for one more dedup.
- **validation.js**'s `_buildChapterContext()` (the AI Tutor's chapter-context builder) — **real bug fix, not just duplication**: it read `ch.chapterTitle` / `chNotes.keyPoints` / `chNotes.pastorals` directly, unnumbered — always `undefined` for a multilingual study (those fields are `chapterTitle1/2/3` etc.). This silently produced `"No additional context available."` for every AI Tutor conversation in every multilingual study. Now resolves all three via the same helpers `render-pages.js`'s Leaders Notes page and the chapter-title call sites above already use.

**Not touched here** (separate, lower-risk concerns noted for later, not expanding this PR's scope): `render-pages.js`'s `renderLeadersNotes()`/`renderGoDeeper()` have their own, unrelated content-block duplication; `tts.js`'s Android-bridge TTS path lacks the chunking safeguard the Web Speech path has (would need native-side/Kotlin changes, can't be done in this JS-only PR series); `render-chapter.js`'s chapter-intro tooltip is gated by a `chapterNumber === 1` literal instead of a data-driven flag.

## Verification (this one especially)
No automated test suite exists in this repo, so given the risk here I ran the new/consolidated logic against the **original** implementations across a full input matrix before committing (see conversation for the actual Node scripts):
- `resolveTextWithFallback()` vs. the original inline chapter-title block: 8 cases (valid slot, slot missing → falls to slot1, slot1 also missing → falls to unnumbered, lang not in langMap [both sub-cases], mono-lingual with/without the field, `langMap: null`) — all byte-identical output.
- `study-loader.js`'s new `_resolveNumberedField()` vs. all three original separate implementations (metadata, slide field, action label) across multilingual and mono-lingual cases — all byte-identical output.
- The `validation.js` fix: built a concrete multilingual study fixture and confirmed the old code produces `"No additional context available."` while the new code correctly resolves the chapter title, key themes, and pastoral context for the active language slot.

All 5 touched files pass `node --check`. A full-codebase grep confirms zero stale references to the removed `_resolveMeta`/`_resolveSlideField` names.

## Test plan
- [ ] Open a chapter in a multilingual study, switch languages via the lang bar — confirm the chapter title updates correctly in the header AND in the prev/next nav buttons.
- [ ] Open a mono-lingual study's chapter — confirm titles/nav still work exactly as before (this path is unchanged in practice, but worth a sanity check).
- [ ] First-run onboarding slides on a multilingual study, in a non-English active language — confirm slide text (eyebrow/heading/body/bodyAfter) and the action button label all show correctly.
- [ ] Open the AI Tutor on a question in a multilingual study (non-English active language) with leaders notes configured — confirm the tutor's responses now reflect actual chapter/key-themes/pastoral context instead of having none.
- [ ] Same AI Tutor check on a mono-lingual study — confirm unaffected.